### PR TITLE
Refactor frontend API and markdown reader

### DIFF
--- a/static/anoweb-front/src/Components/Markdown/MarkdownReaderOverlay.tsx
+++ b/static/anoweb-front/src/Components/Markdown/MarkdownReaderOverlay.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import MarkdownViewer from "./MarkdownViewer";
+import type { MarkdownPayload } from "../../Contexts/markdown_reader";
+
+type Props = {
+  isOpen: boolean;
+  payload: MarkdownPayload | null;
+  isLoading: boolean;
+  onClose: () => void;
+};
+
+export default function MarkdownReaderOverlay({ isOpen, payload, isLoading, onClose }: Props) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  if (!isOpen || !payload) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm flex items-center justify-center p-4" onClick={onClose}>
+      <div
+        className="relative w-[94vw] lg:w-[90vw] max-w-6xl max-h-[88vh] bg-white rounded-3xl shadow-xl border border-slate-200/70 overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-start gap-4 border-b border-slate-200/70 bg-white px-5 py-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-xs uppercase tracking-[0.15em] text-slate-500 mb-1">Central Markdown Reader</p>
+            <h1 className="text-xl md:text-2xl font-semibold text-slate-900 truncate">{payload.title}</h1>
+            {payload.updatedAt && (
+              <p className="text-xs text-slate-500 mt-1">Updated {new Date(payload.updatedAt).toLocaleString()}</p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="h-9 w-9 rounded-full bg-slate-100 text-slate-700 hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            aria-label="Close markdown reader"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-auto bg-[#f6f8fa]">
+          <div className="mx-auto max-w-4xl px-5 py-6">
+            {isLoading ? (
+              <div className="animate-pulse space-y-3">
+                <div className="h-6 bg-slate-200 rounded" />
+                <div className="h-4 bg-slate-200 rounded w-4/5" />
+                <div className="h-64 bg-slate-200/70 rounded" />
+              </div>
+            ) : (
+              <MarkdownViewer source={payload.content ?? ""} />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/static/anoweb-front/src/Components/Markdown/MarkdownViewer.tsx
+++ b/static/anoweb-front/src/Components/Markdown/MarkdownViewer.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import rehypeHighlight from "rehype-highlight";
+
+function getStringChildren(children: React.ReactNode): string {
+  const parts = React.Children.toArray(children).filter((c): c is string => typeof c === "string");
+  return parts.join("");
+}
+
+const components: Components = {
+  code: (({ className, children, ...props }) => {
+    const isBlock = /\blanguage-/.test(className ?? "");
+
+    if (!isBlock) {
+      return (
+        <code className={className} {...props}>
+          {children}
+        </code>
+      );
+    }
+
+    const text = getStringChildren(children);
+    return (
+      <div className="relative group">
+        <pre className="not-prose markdown-pre">
+          <code className={className} {...props}>
+            {children}
+          </code>
+        </pre>
+        {text && (
+          <button
+            type="button"
+            onClick={() => navigator.clipboard?.writeText(text)}
+            className="copy-chip"
+            aria-label="Copy code"
+          >
+            Copy
+          </button>
+        )}
+      </div>
+    );
+  }) as Components["code"],
+  a: (({ href, children, ...props }) => {
+    const isExternal = !!href && /^(https?:)?\/\//i.test(href);
+    return (
+      <a href={href} {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})} {...props}>
+        {children}
+      </a>
+    );
+  }) as Components["a"],
+};
+
+export default function MarkdownViewer({ source }: { source: string }) {
+  return (
+    <article className="markdown-body">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex, [rehypeHighlight, { ignoreMissing: true }]]}
+        components={components}
+      >
+        {source}
+      </ReactMarkdown>
+    </article>
+  );
+}

--- a/static/anoweb-front/src/Components/navbar.tsx
+++ b/static/anoweb-front/src/Components/navbar.tsx
@@ -2,6 +2,7 @@
 import { useContext, useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { AdminContext } from "../Contexts/admin_context";
+import { apiFetch } from "../lib/api";
 
 export default function Navbar() {
   const { isAdmin, setIsAdmin } = useContext(AdminContext);
@@ -41,77 +42,69 @@ export default function Navbar() {
     const pass = prompt("Enter admin password:");
     if (!pass) return;
 
-    try {
-      const res = await fetch("/api/admin", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pass }),
-        credentials: "include",
-      });
-
-      if (res.ok) {
+    apiFetch("/admin", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pass }),
+      credentials: "include",
+    })
+      .then(() => {
         alert("Admin validated!");
         setIsAdmin(true);
-      } else {
-        alert("Invalid password");
+      })
+      .catch(() => {
+        alert("Invalid password or server unreachable");
         setIsAdmin(false);
-      }
-    } catch (err) {
-      alert("Error contacting server");
-      console.error(err);
-      setIsAdmin(false);
-    }
+      });
   };
 
   return (
-    <nav className="sticky top-0 z-50 bg-white/70 backdrop-blur-md shadow-md">
+    <nav className="sticky top-0 z-50 border-b border-slate-200/80 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/80">
       <div className="mx-auto max-w-6xl px-4 md:px-6">
         <div className="h-14 md:h-16 flex items-center justify-between gap-3">
-          {/* Brand (external) */}
           <a
             href="https://zhouzhouzhang.co.uk/"
-            className="shrink-0 text-base md:text-lg font-extrabold tracking-tight text-gray-900 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+            className="flex items-center gap-2 rounded-full px-3 py-1 text-base md:text-lg font-semibold text-slate-900 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
             rel="noopener noreferrer"
           >
-            zhouzhouzhang.co.uk
+            <span className="h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-indigo-500 text-white font-bold grid place-items-center shadow-sm">
+              Z
+            </span>
+            <span>zhouzhouzhang.co.uk</span>
           </a>
 
-          {/* Right side (wrap toggle + menu in one ref for reliable outside-click) */}
           <div className="flex items-center gap-2" ref={menuWrapRef}>
-            {/* Inline nav (md+) */}
-            <div className="hidden md:flex items-center gap-6">
-              <Link to="/" className="text-gray-700 hover:text-blue-600 font-medium">
+            <div className="hidden md:flex items-center gap-4">
+              <Link to="/" className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100">
                 Home
               </Link>
-              <Link to="/about" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link to="/about" className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100">
                 About
               </Link>
-              <Link to="/projects" className="text-gray-700 hover:text-blue-600 font-medium">
+              <Link to="/projects" className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100">
                 Projects
               </Link>
               <button
                 onClick={handleAdminLogin}
-                className="text-gray-700 hover:text-blue-600 font-medium"
+                className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
               >
                 Admin
               </button>
               {isAdmin && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-semibold text-green-700">
-                  <span className="h-2 w-2 rounded-full bg-green-500" /> Admin Mode
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 border border-emerald-100">
+                  <span className="h-2 w-2 rounded-full bg-emerald-500" /> Admin Mode
                 </span>
               )}
             </div>
 
-            {/* Compact admin badge on mobile */}
             {isAdmin && (
-              <span className="md:hidden inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-[10px] font-semibold text-green-700">
-                <span className="h-1.5 w-1.5 rounded-full bg-green-500" /> Admin
+              <span className="md:hidden inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold text-emerald-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Admin
               </span>
             )}
 
-            {/* Hamburger (sm only) */}
             <button
-              className="md:hidden inline-flex items-center justify-center rounded-lg p-2 text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="md:hidden inline-flex items-center justify-center rounded-full p-2 text-slate-700 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
               aria-label="Toggle navigation menu"
               aria-expanded={open}
               aria-controls="mobile-nav"
@@ -125,8 +118,6 @@ export default function Navbar() {
                 )}
               </svg>
             </button>
-
-            {/* Mobile dropdown (inside the same wrapper) */}
           </div>
         </div>
       </div>
@@ -136,15 +127,13 @@ export default function Navbar() {
         className={`md:hidden transition-[max-height,opacity] duration-200 ease-out overflow-hidden ${
           open ? "max-h-64 opacity-100" : "max-h-0 opacity-0"
         }`}
-        // Put the dropdown inside the same wrapper visually (CSS-wise it follows nav)
       >
         <div className="mx-auto max-w-6xl px-4 pb-3">
-          <div className="rounded-2xl border border-gray-200 bg-white/80 backdrop-blur p-2 shadow-sm">
-            <div className="flex items-center justify-between px-1 pb-1">
-              <span className="text-sm font-semibold text-gray-700">Menu</span>
-              {/* Explicit close button for clarity */}
+          <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <div className="flex items-center justify-between px-3 py-2">
+              <span className="text-sm font-semibold text-slate-700">Menu</span>
               <button
-                className="inline-flex items-center justify-center rounded-lg p-2 text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="inline-flex items-center justify-center rounded-full p-2 text-slate-700 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
                 aria-label="Close menu"
                 onClick={() => setOpen(false)}
               >
@@ -156,24 +145,31 @@ export default function Navbar() {
 
             <Link
               to="/"
-              className="block rounded-lg px-3 py-2 text-gray-700 hover:bg-gray-100"
+              className="block rounded-lg px-3 py-2 text-slate-700 hover:bg-slate-50"
               onClick={() => setOpen(false)}
             >
               Home
             </Link>
             <Link
               to="/about"
-              className="block rounded-lg px-3 py-2 text-gray-700 hover:bg-gray-100"
+              className="block rounded-lg px-3 py-2 text-slate-700 hover:bg-slate-50"
               onClick={() => setOpen(false)}
             >
               About
+            </Link>
+            <Link
+              to="/projects"
+              className="block rounded-lg px-3 py-2 text-slate-700 hover:bg-slate-50"
+              onClick={() => setOpen(false)}
+            >
+              Projects
             </Link>
             <button
               onClick={() => {
                 setOpen(false);
                 handleAdminLogin();
               }}
-              className="block w-full text-left rounded-lg px-3 py-2 text-gray-700 hover:bg-gray-100"
+              className="block w-full text-left rounded-lg px-3 py-2 text-slate-700 hover:bg-slate-50"
             >
               Admin
             </button>

--- a/static/anoweb-front/src/Contexts/admin_context.tsx
+++ b/static/anoweb-front/src/Contexts/admin_context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useState, useEffect, type ReactNode } from "react";
+import { apiJson } from "../lib/api";
 
 interface AdminContextType {
   isAdmin: boolean;
@@ -14,8 +15,7 @@ export function AdminProvider({ children }: { children: ReactNode }) {
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    fetch("/api/admin/status", { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : { isAdmin: false }))
+    apiJson<{ isAdmin: boolean }>("/admin/status", { credentials: "include" })
       .then((data) => setIsAdmin(!!data.isAdmin))
       .catch(() => setIsAdmin(false));
   }, []);

--- a/static/anoweb-front/src/Contexts/markdown_reader.tsx
+++ b/static/anoweb-front/src/Contexts/markdown_reader.tsx
@@ -1,0 +1,74 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import { apiJson } from "../lib/api";
+import type { Post } from "../Pages/Projects/types";
+import MarkdownReaderOverlay from "../Components/Markdown/MarkdownReaderOverlay";
+
+export type MarkdownPayload = {
+  title?: string;
+  content?: string;
+  updatedAt?: string;
+  sourceId?: number;
+};
+
+export type MarkdownReaderContextType = {
+  openReader: (payload: MarkdownPayload) => void;
+  closeReader: () => void;
+};
+
+const MarkdownReaderContext = createContext<MarkdownReaderContextType>({
+  openReader: () => {},
+  closeReader: () => {},
+});
+
+export function MarkdownReaderProvider({ children }: { children: ReactNode }) {
+  const [current, setCurrent] = useState<MarkdownPayload | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const closeReader = useCallback(() => {
+    setCurrent(null);
+    setIsLoading(false);
+  }, []);
+
+  const openReader = useCallback((payload: MarkdownPayload) => {
+    setCurrent({ title: payload.title ?? "Untitled", content: payload.content ?? "", updatedAt: payload.updatedAt, sourceId: payload.sourceId });
+
+    if (payload.sourceId) {
+      setIsLoading(true);
+      apiJson<Post>(`/project/post/${payload.sourceId}`)
+        .then((post) =>
+          setCurrent({
+            title: post.name,
+            content: post.content_md ?? "",
+            updatedAt: post.updated_at,
+            sourceId: payload.sourceId,
+          })
+        )
+        .catch((err) => {
+          setCurrent({
+            title: payload.title ?? "Unable to load markdown",
+            content: err instanceof Error ? err.message : "Unknown error",
+            updatedAt: payload.updatedAt,
+          });
+        })
+        .finally(() => setIsLoading(false));
+    }
+  }, []);
+
+  const value = useMemo(() => ({ openReader, closeReader }), [openReader, closeReader]);
+
+  return (
+    <MarkdownReaderContext.Provider value={value}>
+      {children}
+      <MarkdownReaderOverlay
+        isOpen={!!current}
+        payload={current}
+        isLoading={isLoading}
+        onClose={closeReader}
+      />
+    </MarkdownReaderContext.Provider>
+  );
+}
+
+export function useMarkdownReader() {
+  return useContext(MarkdownReaderContext);
+}

--- a/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
@@ -1,5 +1,6 @@
 import { useContext } from "react";
 import { AdminContext } from "../../Contexts/admin_context";
+import { apiFetch } from "../../lib/api";
 import type { Experience } from "./types";
 
 type ExperienceCardProps = {
@@ -20,7 +21,7 @@ export default function ExperienceCard({ experience, setExperience }: Experience
     current.splice(toIndex, 0, moved);
     const reindexed = current.map((item, idx) => ({ ...item, order_index: idx }));
     setExperience(reindexed);
-    fetch("/api/home/experience/order", {
+    apiFetch("/home/experience/order", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(reindexed.map((it, idx) => ({ id: it.id, order_index: idx }))),

--- a/static/anoweb-front/src/Pages/Home/index.tsx
+++ b/static/anoweb-front/src/Pages/Home/index.tsx
@@ -14,95 +14,72 @@ export default function Home() {
     useHomeData();
 
   return (
-    <div className="min-h-screen p-4 md:p-8 bg-gradient-to-r from-blue-100 to-purple-200">
-      <div className="max-w-6xl mx-auto">
-        {/* One row, three columns; all columns stretch to the tallest */}
-        <div className="grid gap-6 lg:grid-cols-[340px_minmax(0,1fr)_380px] items-stretch">
-          {/* ===== Column 1 (equal height) ===== */}
-          <div className="flex flex-col h-full gap-4">
-            <div>
-              <ProfileCard profile={profile} />
-            </div>
-            {/* Push the tiles to the bottom so this column matches others */}
-            <div className="flex-1" />
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {/* Admin left, Latest right */}
-              <div className="bg-white rounded-2xl shadow-lg p-6 w-full">
-                <h2 className="text-lg font-semibold text-gray-800 mb-2 text-center">
-                  Admin Status
-                </h2>
-                {isAdmin ? (
-                  <div className="flex flex-col items-center text-center space-y-2">
-                    <span className="text-3xl">🛡️</span>
-                    <p className="text-green-700 font-bold">
-                      You are now in{" "}
-                      <span className="underline">Admin Mode</span>!
-                    </p>
-                  </div>
-                ) : (
-                  <div className="flex flex-col items-center text-center space-y-2">
-                    <span className="text-3xl">🙅</span>
-                    <p className="text-red-600 font-bold">
-                      No admin rights for you!
-                    </p>
-                  </div>
-                )}
-              </div>
+    <div className="space-y-8">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm uppercase tracking-[0.18em] text-slate-500">Welcome</p>
+          <h1 className="text-3xl font-semibold text-slate-900">Home</h1>
+        </div>
+        <span className="rounded-full bg-blue-50 text-blue-700 px-4 py-2 text-sm font-medium">Google-inspired layout</span>
+      </div>
 
-              <LatestPostCard post={latestPost} size="compact" />
+      <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)_340px] items-stretch">
+        <div className="flex flex-col h-full gap-4">
+          <ProfileCard profile={profile} />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 w-full">
+              <h2 className="text-lg font-semibold text-slate-900 mb-2 text-center">Admin Status</h2>
+              {isAdmin ? (
+                <div className="flex flex-col items-center text-center space-y-2">
+                  <span className="text-3xl">🛡️</span>
+                  <p className="text-emerald-700 font-semibold">You are now in Admin Mode!</p>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center text-center space-y-2">
+                  <span className="text-3xl">🙅</span>
+                  <p className="text-rose-600 font-semibold">No admin rights for you!</p>
+                </div>
+              )}
             </div>
 
+            <LatestPostCard post={latestPost} size="compact" />
           </div>
-          {/* ===== Column 2 (equal height) ===== */}
-          <div className="flex flex-col h-full gap-3">
-            {/* Education ~40% */}
-            <div className="basis-0 flex-[2] flex [&>*]:h-full">
-              <EducationCard education={education} />
-            </div>
+        </div>
 
-            {/* Experience ~60% */}
-            <div className="basis-0 flex-[3] flex [&>*]:h-full">
-              <ExperienceCard
-                experience={experience}
-                setExperience={setExperience}
-              />
-            </div>
+        <div className="flex flex-col h-full gap-3">
+          <div className="basis-0 flex-[2] flex [&>*]:h-full">
+            <EducationCard education={education} />
           </div>
 
-          {/* ===== Column 3 (equal height) ===== */}
-          <div className="flex flex-col h-full gap-4">
-            <Link
-              to="/projects"
-              className="bg-white rounded-2xl shadow-lg p-6 w-full transition-transform duration-150 hover:scale-[1.01] hover:shadow-xl no-underline flex flex-1"
-            >
-              <div className="m-auto text-center flex flex-col items-center">
-                <h2 className="text-lg font-semibold text-gray-800 mb-3">
-                  Projects
-                </h2>
-                <span className="text-4xl mb-2">🚀</span>
-                <p className="text-gray-600 max-w-[22ch]">
-                  Explore my portfolio of work and personal projects.
-                </p>
-              </div>
-            </Link>
-
-            <a
-              href="https://drive.google.com/file/d/1lJQSIysTrcrDtCgAK0koo-gIb0rhaJAK/view?usp=sharing"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bg-white rounded-2xl shadow-lg p-6 w-full transition-transform duration-150 hover:scale-[1.01] hover:shadow-xl no-underline flex"
-            >
-              <div className="m-auto text-center flex flex-col items-center">
-                <h2 className="text-lg font-semibold text-gray-800 mb-3">
-                  View My CV
-                </h2>
-                <span className="text-4xl mb-2">📄</span>
-                <p className="text-gray-600 max-w-[24ch]">
-                  Download my resume to explore my experience and skills in depth.
-                </p>
-              </div>
-            </a>
+          <div className="basis-0 flex-[3] flex [&>*]:h-full">
+            <ExperienceCard experience={experience} setExperience={setExperience} />
           </div>
+        </div>
+
+        <div className="flex flex-col h-full gap-4">
+          <Link
+            to="/projects"
+            className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 w-full transition-transform duration-150 hover:scale-[1.01] hover:shadow-md no-underline flex flex-1"
+          >
+            <div className="m-auto text-center flex flex-col items-center">
+              <h2 className="text-lg font-semibold text-slate-900 mb-3">Projects</h2>
+              <span className="text-4xl mb-2">🚀</span>
+              <p className="text-slate-600 max-w-[22ch]">Explore my portfolio of work and personal projects.</p>
+            </div>
+          </Link>
+
+          <a
+            href="https://drive.google.com/file/d/1lJQSIysTrcrDtCgAK0koo-gIb0rhaJAK/view?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 w-full transition-transform duration-150 hover:scale-[1.01] hover:shadow-md no-underline flex"
+          >
+            <div className="m-auto text-center flex flex-col items-center">
+              <h2 className="text-lg font-semibold text-slate-900 mb-3">View My CV</h2>
+              <span className="text-4xl mb-2">📄</span>
+              <p className="text-slate-600 max-w-[24ch]">Download my resume to explore my experience and skills in depth.</p>
+            </div>
+          </a>
         </div>
       </div>
     </div>

--- a/static/anoweb-front/src/Pages/Home/useHomeData.ts
+++ b/static/anoweb-front/src/Pages/Home/useHomeData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { apiJson } from "../../lib/api";
 import type { Profile, Education, Experience, Post } from "./types";
 
 export function useHomeData() {
@@ -8,25 +9,10 @@ export function useHomeData() {
   const [latestPost, setLatestPost] = useState<Post | null>(null);
 
   useEffect(() => {
-    fetch("/api/home/profile-info")
-      .then((r) => r.json())
-      .then((d: Profile) => setProfile(d))
-      .catch(() => setProfile(null));
-
-    fetch("/api/home/education")
-      .then((r) => r.json())
-      .then((d: Education[]) => setEducation(d))
-      .catch(() => setEducation([]));
-
-    fetch("/api/home/experience")
-      .then((r) => r.json())
-      .then((d: Experience[]) => setExperience(d))
-      .catch(() => setExperience([]));
-
-    fetch("/api/home/post/latest")
-      .then((r) => r.json())
-      .then((d: Post) => setLatestPost(d))
-      .catch(() => setLatestPost(null));
+    apiJson<Profile>("/home/profile-info").then(setProfile).catch(() => setProfile(null));
+    apiJson<Education[]>("/home/education").then(setEducation).catch(() => setEducation([]));
+    apiJson<Experience[]>("/home/experience").then(setExperience).catch(() => setExperience([]));
+    apiJson<Post>("/home/post/latest").then(setLatestPost).catch(() => setLatestPost(null));
   }, []);
 
   return { profile, education, experience, setExperience, latestPost };

--- a/static/anoweb-front/src/Pages/Projects/CreatePostModal.tsx
+++ b/static/anoweb-front/src/Pages/Projects/CreatePostModal.tsx
@@ -1,10 +1,7 @@
 // src/components/ProjectPage/CreatePostModal.tsx
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import rehypeKatex from "rehype-katex";
-import rehypeHighlight from "rehype-highlight";
+import MarkdownViewer from "../../Components/Markdown/MarkdownViewer";
+import { apiFetch } from "../../lib/api";
 
 type CreatePostModalProps = {
   onClose: () => void;
@@ -61,7 +58,7 @@ export default function CreatePostModal({
     const formData = new FormData();
     formData.append("file", file);
     try {
-      const res = await fetch("/api/static/upload-image", { method: "POST", body: formData });
+      const res = await apiFetch("/static/upload-image", { method: "POST", body: formData });
       if (!res.ok) throw new Error("Image upload failed");
       const url = await res.text();
       const md = `![alt text](${url})`;
@@ -88,7 +85,7 @@ export default function CreatePostModal({
     setIsSubmitting(true);
     setError(null);
     try {
-      const res = await fetch("/api/project/post", {
+      const res = await apiFetch("/project/post", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ parent_id: parentId, name, content_md: contentMD }),
@@ -180,15 +177,8 @@ export default function CreatePostModal({
 
             {/* Preview */}
             <div className={`${tab === "preview" ? "block" : "hidden"} md:block`}>
-              <div className="h-[55vh] overflow-auto rounded-xl border border-slate-200 p-3 sm:p-4 scrollbar-clear">
-                <article className="prose max-w-none prose-a:text-blue-700 prose-img:rounded-xl">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm, remarkMath]}
-                    rehypePlugins={[rehypeKatex, [rehypeHighlight, { ignoreMissing: true }]]}
-                  >
-                    {contentMD}
-                  </ReactMarkdown>
-                </article>
+              <div className="h-[55vh] overflow-auto rounded-xl border border-slate-200 bg-white p-3 sm:p-4 scrollbar-clear">
+                <MarkdownViewer source={contentMD} />
               </div>
             </div>
           </div>

--- a/static/anoweb-front/src/Pages/Projects/CreateProjectModal.tsx
+++ b/static/anoweb-front/src/Pages/Projects/CreateProjectModal.tsx
@@ -1,6 +1,7 @@
 // src/components/ProjectPage/CreateProjectModal.tsx
 
 import { useState } from "react";
+import { apiFetch } from "../../lib/api";
 
 type CreateProjectModalProps = {
   onClose: () => void;
@@ -27,7 +28,7 @@ export default function CreateProjectModal({ onClose, onSuccess }: CreateProject
     formData.append("file", file);
 
     try {
-      const response = await fetch("/api/static/upload-image", {
+      const response = await apiFetch("/static/upload-image", {
         method: "POST",
         body: formData,
       });
@@ -56,7 +57,7 @@ export default function CreateProjectModal({ onClose, onSuccess }: CreateProject
     setError(null);
 
     try {
-      const response = await fetch("/api/project", {
+      const response = await apiFetch("/project", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name, description, link, image_url: imageUrl }),

--- a/static/anoweb-front/src/Pages/Projects/ProjectDetails.tsx
+++ b/static/anoweb-front/src/Pages/Projects/ProjectDetails.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useContext, useEffect } from "react";
 import { AdminContext } from "../../Contexts/admin_context";
+import { apiFetch } from "../../lib/api";
 import { type Project } from "./types";
 
 type ProjectDetailsProps = {
@@ -35,7 +36,7 @@ export function ProjectDetails({ project, onProjectUpdate }: ProjectDetailsProps
     data.append("file", file);
 
     try {
-      const response = await fetch("/api/static/upload-image", { method: "POST", body: data });
+      const response = await apiFetch("/static/upload-image", { method: "POST", body: data });
       if (!response.ok) throw new Error("Image upload failed");
       const url = await response.text();
       setFormData((prev) => ({ ...prev, image_url: url }));
@@ -52,7 +53,7 @@ export function ProjectDetails({ project, onProjectUpdate }: ProjectDetailsProps
     setError(null);
 
     try {
-      const response = await fetch("/api/project", {
+      const response = await apiFetch("/project", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...formData }),

--- a/static/anoweb-front/src/Pages/Projects/index.tsx
+++ b/static/anoweb-front/src/Pages/Projects/index.tsx
@@ -5,7 +5,6 @@ import { useProjectData } from "./useProjectData";
 import ProjectList from "./ProjectList";
 import { ProjectDetails } from "./ProjectDetails";
 import { PostCardRail } from "./PostCardRail";
-import { PostDetailModal } from "./PostDetailModal";
 import CreateProjectModal from "./CreateProjectModal";
 import CreatePostModal from "./CreatePostModal";
 
@@ -36,14 +35,11 @@ export default function ProjectPage() {
   const {
     projects,
     posts,
-    viewingPost,
     selectedProjectId,
     selectedProject,
     isLoadingProjects,
     isLoadingPosts,
-    isLoadingPostDetail,
     setSelectedProjectId,
-    setViewingPost,
     handleViewPost,
     isCreateModalOpen,
     openCreateModal,
@@ -115,15 +111,6 @@ export default function ProjectPage() {
             </div>
           )}
         </main>
-
-        {/* Post Detail Modal (conditionally rendered) */}
-        {viewingPost && (
-          <PostDetailModal
-            post={viewingPost}
-            isLoading={isLoadingPostDetail}
-            onClose={() => setViewingPost(null)}
-          />
-        )}
 
         {/* Create Project Modal (conditionally rendered) */}
         {isCreateModalOpen && (

--- a/static/anoweb-front/src/Pages/Projects/useProjectData.ts
+++ b/static/anoweb-front/src/Pages/Projects/useProjectData.ts
@@ -1,27 +1,27 @@
 // src/components/ProjectPage/useProjectData.ts
 
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { type Project, type PostShort, type Post } from "./types";
+import { apiFetch, apiJson } from "../../lib/api";
+import { useMarkdownReader } from "../../Contexts/markdown_reader";
+import { type Project, type PostShort } from "./types";
 
 export function useProjectData() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [posts, setPosts] = useState<PostShort[]>([]);
 
-  const [viewingPost, setViewingPost] = useState<Post | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
     null
   );
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
   const [isLoadingPosts, setIsLoadingPosts] = useState(false);
-  const [isLoadingPostDetail, setIsLoadingPostDetail] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState(false);
+  const { openReader } = useMarkdownReader();
 
   const refreshProjects = useCallback(() => {
     setIsLoadingProjects(true);
-    fetch("/api/project")
-      .then((res) => res.json())
-      .then((data: Project[]) => {
+    apiJson<Project[]>("/project")
+      .then((data) => {
         setProjects(data);
         if (data.length > 0 && selectedProjectId === null) {
           setSelectedProjectId(data[0].id);
@@ -40,8 +40,7 @@ export function useProjectData() {
 
     setIsLoadingPosts(true);
     setPosts([]);
-    fetch(`/api/project/${selectedProjectId}/posts`)
-      .then((res) => res.json())
+    apiJson<PostShort[]>(`/project/${selectedProjectId}/posts`)
       .then((data) => {
         if (Array.isArray(data)) {
           setPosts(data);
@@ -62,21 +61,7 @@ export function useProjectData() {
   }, [refreshPosts, selectedProjectId]);
 
   const handleViewPost = (postId: number) => {
-    setIsLoadingPostDetail(true);
-    setViewingPost({
-      id: postId,
-      name: "Loading...",
-      content_md: "Please wait...",
-      updated_at: "",
-    });
-
-    fetch(`/api/project/post/${postId}`)
-      .then((res) => res.json())
-      .then((data: Post) => {
-        setViewingPost(data);
-      })
-      .catch(console.error)
-      .finally(() => setIsLoadingPostDetail(false));
+    openReader({ title: "Loading post", content: "", sourceId: postId });
   };
 
   const handleDeletePost = useCallback(
@@ -86,13 +71,9 @@ export function useProjectData() {
       }
 
       try {
-        const response = await fetch(`/api/project/post/${postId}`, {
+        await apiFetch(`/project/post/${postId}`, {
           method: "DELETE",
         });
-
-        if (!response.ok) {
-          throw new Error("Failed to delete post");
-        }
 
         refreshPosts();
       } catch (err) {
@@ -110,14 +91,11 @@ export function useProjectData() {
   return {
     projects,
     posts,
-    viewingPost,
     selectedProjectId,
     selectedProject,
     isLoadingProjects,
     isLoadingPosts,
-    isLoadingPostDetail,
     setSelectedProjectId,
-    setViewingPost,
     handleViewPost,
     isCreateModalOpen,
     openCreateModal: () => setIsCreateModalOpen(true),

--- a/static/anoweb-front/src/lib/api.ts
+++ b/static/anoweb-front/src/lib/api.ts
@@ -1,0 +1,27 @@
+const env = (import.meta as any).env || {};
+const API_BASE = (env.VITE_API_BASE_URL || "/api").replace(/\/$/, "");
+
+export function apiUrl(path: string) {
+  if (path.startsWith("http")) return path;
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${API_BASE}${normalized}`;
+}
+
+async function handleResponse(res: Response) {
+  if (!res.ok) {
+    const message = await res.text().catch(() => res.statusText);
+    throw new Error(message || `Request failed with ${res.status}`);
+  }
+  return res;
+}
+
+export async function apiFetch(input: string, init?: RequestInit) {
+  const target = apiUrl(input);
+  const response = await fetch(target, init);
+  return handleResponse(response);
+}
+
+export async function apiJson<T>(input: string, init?: RequestInit) {
+  const res = await apiFetch(input, init);
+  return (await res.json()) as T;
+}

--- a/static/anoweb-front/src/main.tsx
+++ b/static/anoweb-front/src/main.tsx
@@ -3,18 +3,21 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import AppRouter from "./App";
 import { AdminProvider } from "./Contexts/admin_context";
+import { MarkdownReaderProvider } from "./Contexts/markdown_reader";
 import Navbar from "./Components/navbar";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
       <AdminProvider>
-        <div className="min-h-screen w-full flex flex-col bg-gradient-to-r from-blue-100 to-purple-200">
-          <Navbar />
-          <main className="flex-1 p-4 md:p-8">
-            <AppRouter />
-          </main>
-        </div>
+        <MarkdownReaderProvider>
+          <div className="min-h-screen w-full bg-[#f5f7fb] text-slate-900">
+            <Navbar />
+            <main className="mx-auto max-w-6xl px-4 pb-12 pt-6 md:pt-10 md:px-8">
+              <AppRouter />
+            </main>
+          </div>
+        </MarkdownReaderProvider>
       </AdminProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/static/anoweb-front/src/style.css
+++ b/static/anoweb-front/src/style.css
@@ -38,3 +38,52 @@
 /* Optional: nicer markdown defaults */
 .prose a { color: rgb(29 78 216); }              /* blue-700 */
 .prose img { border-radius: 0.75rem; }           /* rounded-xl */
+
+/* —— GitHub-like Markdown styling —— */
+.markdown-body {
+  font-family: "Roboto", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #24292f;
+  line-height: 1.7;
+  font-size: 16px;
+}
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3 {
+  color: #1f2937;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #d0d7de;
+}
+.markdown-body code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.95em;
+  background: #f6f8fa;
+  padding: 0.2em 0.4em;
+  border-radius: 6px;
+}
+.markdown-body pre code {
+  padding: 0;
+  background: transparent;
+}
+.markdown-pre {
+  padding: 16px;
+  background: #f6f8fa;
+  border-radius: 12px;
+  overflow: auto;
+  border: 1px solid #d0d7de;
+}
+.copy-chip {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 6px 10px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+  background: #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  opacity: 0;
+  transition: opacity 0.2s ease, background 0.2s ease;
+}
+.group:hover .copy-chip { opacity: 1; }
+.copy-chip:hover { background: #d1d5db; }


### PR DESCRIPTION
## Summary
- centralize API access through a configurable client and update all calls
- introduce a global markdown reader overlay with GitHub-like rendering and shared preview styling
- refresh layouts with Google-inspired surfaces and spacing while keeping the app buildable

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac2b11fb08332b37945e06585c9f7)