### PR TITLE
Refactor frontend to match updated backend API

### DIFF
--- a/static/anoweb-front/src/Contexts/markdown_reader.tsx
+++ b/static/anoweb-front/src/Contexts/markdown_reader.tsx
@@ -34,7 +34,7 @@ export function MarkdownReaderProvider({ children }: { children: ReactNode }) {
 
     if (payload.sourceId) {
       setIsLoading(true);
-      apiJson<Post>(`/project/post/${payload.sourceId}`)
+      apiJson<Post>(`/post/${payload.sourceId}`)
         .then((post) =>
           setCurrent({
             title: post.name,

--- a/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
@@ -21,7 +21,7 @@ export default function ExperienceCard({ experience, setExperience }: Experience
     current.splice(toIndex, 0, moved);
     const reindexed = current.map((item, idx) => ({ ...item, order_index: idx }));
     setExperience(reindexed);
-    apiFetch("/home/experience/order", {
+    apiFetch("/experience/order", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(reindexed.map((it, idx) => ({ id: it.id, order_index: idx }))),

--- a/static/anoweb-front/src/Pages/Home/types.ts
+++ b/static/anoweb-front/src/Pages/Home/types.ts
@@ -24,6 +24,7 @@ export type Experience = {
   start_date: string;
   end_date: string;
   present: boolean;
+  description?: string;
   image_url: string;
   order_index: number;
 };

--- a/static/anoweb-front/src/Pages/Home/useHomeData.ts
+++ b/static/anoweb-front/src/Pages/Home/useHomeData.ts
@@ -9,10 +9,12 @@ export function useHomeData() {
   const [latestPost, setLatestPost] = useState<Post | null>(null);
 
   useEffect(() => {
-    apiJson<Profile>("/home/profile-info").then(setProfile).catch(() => setProfile(null));
-    apiJson<Education[]>("/home/education").then(setEducation).catch(() => setEducation([]));
-    apiJson<Experience[]>("/home/experience").then(setExperience).catch(() => setExperience([]));
-    apiJson<Post>("/home/post/latest").then(setLatestPost).catch(() => setLatestPost(null));
+    apiJson<Profile>("/profile").then(setProfile).catch(() => setProfile(null));
+    apiJson<Education[]>("/education").then(setEducation).catch(() => setEducation([]));
+    apiJson<Experience[]>("/experience/short")
+      .then(setExperience)
+      .catch(() => setExperience([]));
+    apiJson<Post>("/post/latest").then(setLatestPost).catch(() => setLatestPost(null));
   }, []);
 
   return { profile, education, experience, setExperience, latestPost };

--- a/static/anoweb-front/src/Pages/Projects/CreatePostModal.tsx
+++ b/static/anoweb-front/src/Pages/Projects/CreatePostModal.tsx
@@ -85,7 +85,7 @@ export default function CreatePostModal({
     setIsSubmitting(true);
     setError(null);
     try {
-      const res = await apiFetch("/project/post", {
+      const res = await apiFetch("/post", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ parent_id: parentId, name, content_md: contentMD }),

--- a/static/anoweb-front/src/Pages/Projects/types.ts
+++ b/static/anoweb-front/src/Pages/Projects/types.ts
@@ -4,18 +4,25 @@ export type Project = {
   description: string;
   link: string;
   image_url: string;
+  created_at?: string;
+  updated_at?: string;
 };
 
 export type PostShort = {
   id: number;
   parent_id: number;
+  parent_type?: string;
   name: string;
+  created_at?: string;
   updated_at: string;
 };
 
 export type Post = {
   id: number;
+  parent_id: number;
+  parent_type?: string;
   name: string;
   content_md: string;
+  created_at?: string;
   updated_at: string;
 };

--- a/static/anoweb-front/src/Pages/Projects/useProjectData.ts
+++ b/static/anoweb-front/src/Pages/Projects/useProjectData.ts
@@ -40,7 +40,7 @@ export function useProjectData() {
 
     setIsLoadingPosts(true);
     setPosts([]);
-    apiJson<PostShort[]>(`/project/${selectedProjectId}/posts`)
+    apiJson<PostShort[]>(`/post/project/${selectedProjectId}`)
       .then((data) => {
         if (Array.isArray(data)) {
           setPosts(data);
@@ -71,7 +71,7 @@ export function useProjectData() {
       }
 
       try {
-        await apiFetch(`/project/post/${postId}`, {
+        await apiFetch(`/post/${postId}`, {
           method: "DELETE",
         });
 


### PR DESCRIPTION
## Summary
- update home data requests to use the new profile, education, experience, and post endpoints
- align project and post interactions with the new API routes and response shapes
- refresh shared types to reflect backend fields and ensure admin reorder uses the new path

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac5def5b08332b8d3d5f890f09f1a)