### PR TITLE
Revamp frontend with Google-inspired UI

### DIFF
--- a/static/anoweb-front/src/Components/navbar.tsx
+++ b/static/anoweb-front/src/Components/navbar.tsx
@@ -59,52 +59,51 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="sticky top-0 z-50 border-b border-slate-200/80 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/80">
-      <div className="mx-auto max-w-6xl px-4 md:px-6">
+    <nav className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b border-slate-200/80 shadow-[0_1px_0_rgba(0,0,0,0.04)]">
+      <div className="mx-auto max-w-6xl px-4 md:px-6" ref={menuWrapRef}>
         <div className="h-14 md:h-16 flex items-center justify-between gap-3">
           <a
             href="https://zhouzhouzhang.co.uk/"
-            className="flex items-center gap-2 rounded-full px-3 py-1 text-base md:text-lg font-semibold text-slate-900 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
+            className="flex items-center gap-3 rounded-full px-3 py-1 text-base md:text-lg font-semibold text-slate-900 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
             rel="noopener noreferrer"
           >
-            <span className="h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-indigo-500 text-white font-bold grid place-items-center shadow-sm">
+            <span className="h-10 w-10 rounded-full bg-gradient-to-br from-blue-500 via-blue-600 to-indigo-600 text-white font-bold grid place-items-center shadow-sm">
               Z
             </span>
-            <span>zhouzhouzhang.co.uk</span>
+            <div className="flex flex-col leading-tight">
+              <span className="text-[13px] uppercase tracking-[0.18em] text-slate-500">Portfolio</span>
+              <span className="-mt-0.5">zhouzhouzhang.co.uk</span>
+            </div>
           </a>
 
-          <div className="flex items-center gap-2" ref={menuWrapRef}>
-            <div className="hidden md:flex items-center gap-4">
-              <Link to="/" className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100">
-                Home
-              </Link>
-              <Link to="/about" className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100">
-                About
-              </Link>
-              <Link to="/projects" className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100">
-                Projects
-              </Link>
-              <button
-                onClick={handleAdminLogin}
-                className="rounded-full px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
-              >
-                Admin
-              </button>
-              {isAdmin && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 border border-emerald-100">
-                  <span className="h-2 w-2 rounded-full bg-emerald-500" /> Admin Mode
-                </span>
-              )}
-            </div>
-
+          <div className="hidden md:flex items-center gap-2 rounded-full bg-slate-50/80 px-2 py-1 border border-slate-200">
+            <Link to="/" className="nav-chip">
+              Home
+            </Link>
+            <Link to="/about" className="nav-chip">
+              About
+            </Link>
+            <Link to="/projects" className="nav-chip">
+              Projects
+            </Link>
+            <button onClick={handleAdminLogin} className="nav-chip text-blue-700">
+              Admin
+            </button>
             {isAdmin && (
-              <span className="md:hidden inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold text-emerald-700">
+              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 border border-emerald-100">
+                <span className="h-2 w-2 rounded-full bg-emerald-500" /> Admin
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 md:hidden">
+            {isAdmin && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold text-emerald-700">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Admin
               </span>
             )}
-
             <button
-              className="md:hidden inline-flex items-center justify-center rounded-full p-2 text-slate-700 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
+              className="inline-flex items-center justify-center rounded-full p-2 text-slate-700 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
               aria-label="Toggle navigation menu"
               aria-expanded={open}
               aria-controls="mobile-nav"
@@ -131,7 +130,7 @@ export default function Navbar() {
         <div className="mx-auto max-w-6xl px-4 pb-3">
           <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
             <div className="flex items-center justify-between px-3 py-2">
-              <span className="text-sm font-semibold text-slate-700">Menu</span>
+              <span className="text-sm font-semibold text-slate-700">Quick links</span>
               <button
                 className="inline-flex items-center justify-center rounded-full p-2 text-slate-700 hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
                 aria-label="Close menu"

--- a/static/anoweb-front/src/Pages/About/about.tsx
+++ b/static/anoweb-front/src/Pages/About/about.tsx
@@ -1,4 +1,31 @@
 
 export default function About() {
-    return <h1 className="text-2xl font-bold">About Page</h1>;
+  return (
+    <section className="rounded-3xl bg-white/90 border border-slate-200 shadow-lg p-6 md:p-10 space-y-4">
+      <p className="text-xs uppercase tracking-[0.2em] text-slate-500">About</p>
+      <h1 className="text-3xl font-semibold text-slate-900">Designing with a Google-inspired lens</h1>
+      <p className="text-slate-700 leading-relaxed">
+        This UI leans on the clarity and restraint of Google Cloud and Chrome: generous white space, quiet borders, and subtle
+        gradients that highlight the content pulled directly from the Go backend. Everything you see—from profile data to
+        posts—travels through the documented APIs.
+      </p>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+          <h2 className="text-lg font-semibold text-slate-900">Tech stack</h2>
+          <ul className="mt-2 space-y-1 text-sm text-slate-700 list-disc list-inside">
+            <li>React + Vite front end with Tailwind CSS</li>
+            <li>Central markdown reader powered by the post endpoints</li>
+            <li>Go backend exposing profile, education, experience, projects, and post APIs</li>
+          </ul>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+          <h2 className="text-lg font-semibold text-slate-900">Philosophy</h2>
+          <p className="text-sm text-slate-700 leading-relaxed">
+            Put the data first, then add the lightest possible chrome: rounded surfaces, soft color, and strong typography. The
+            result should feel like a console you want to keep open.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/static/anoweb-front/src/Pages/Home/EducationCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/EducationCard.tsx
@@ -8,24 +8,35 @@ export default function EducationCard({ education }: EducationCardProps) {
   if (education.length === 0) return null;
 
   return (
-    <div className="bg-white rounded-2xl shadow-lg p-6 w-full h-full flex flex-col">
-      <h2 className="text-lg font-semibold text-gray-800 mb-3">Education</h2>
-      <ul className="space-y-3 flex-1 overflow-auto">
+    <article className="bg-white/90 rounded-3xl shadow-lg border border-slate-200 p-6 md:p-8 h-full flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Education</p>
+          <h2 className="text-xl font-semibold text-slate-900">Academic trail</h2>
+        </div>
+        <span className="rounded-full bg-indigo-50 text-indigo-700 px-3 py-1 text-xs font-semibold border border-indigo-100">
+          {education.length} entries
+        </span>
+      </div>
+      <ul className="space-y-3 flex-1 overflow-auto scrollbar-clear">
         {education.map((edu) => (
           <li
             key={edu.id}
-            className="flex items-center gap-3 p-3 rounded-xl cursor-pointer transition-transform duration-200 hover:scale-[1.01] hover:shadow-md"
+            className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-r from-white to-slate-50 hover:from-indigo-50/50 hover:to-white p-4 transition-all duration-200 shadow-sm"
             onClick={() => window.open(edu.link, "_blank")}
           >
-            <img src={edu.image_url} alt={edu.school} className="w-12 h-12 rounded-md object-cover shadow-sm" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-gray-800 truncate">{edu.school}</p>
-              <p className="text-xs text-gray-600 truncate">{edu.degree}</p>
-              <p className="text-xs text-gray-500">{edu.start_date} – {edu.end_date}</p>
+            <div className="flex items-center gap-4">
+              <img src={edu.image_url} alt={edu.school} className="w-12 h-12 rounded-lg object-cover shadow-sm border border-slate-200" />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-slate-900 truncate">{edu.school}</p>
+                <p className="text-xs text-slate-600 truncate">{edu.degree}</p>
+                <p className="text-xs text-slate-500">{edu.start_date} – {edu.end_date}</p>
+              </div>
+              <div className="hidden sm:block text-[11px] font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-full px-3 py-1">View</div>
             </div>
           </li>
         ))}
       </ul>
-    </div>
+    </article>
   );
 }

--- a/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
@@ -30,36 +30,56 @@ export default function ExperienceCard({ experience, setExperience }: Experience
   };
 
   return (
-    <div className="bg-white rounded-2xl shadow-lg p-6 w-full h-full flex flex-col">
-      <h2 className="text-lg font-semibold text-gray-800 mb-3">Experience</h2>
-      <ul className="space-y-3 flex-1 overflow-auto">
-        {ordered.map((exp, index) => {
-          const endDisplay = exp.present ? "Present" : exp.end_date;
-          return (
-            <li
-              key={exp.id}
-              draggable={isAdmin}
-              onDragStart={(e) => isAdmin && e.dataTransfer.setData("text/plain", String(index))}
-              onDragOver={(e) => isAdmin && e.preventDefault()}
-              onDrop={(e) => {
-                if (!isAdmin) return;
-                const fromIndex = Number(e.dataTransfer.getData("text/plain"));
-                handleDrop(fromIndex, index);
-              }}
-              className={`flex items-center gap-3 p-3 rounded-xl transition-transform duration-200 hover:scale-[1.01] hover:shadow-md ${
-                isAdmin ? "cursor-grab border border-dashed border-gray-300" : "cursor-pointer"
-              }`}
-            >
-              <img src={exp.image_url} alt={exp.company} className="w-12 h-12 rounded-md object-cover shadow-sm" />
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-800 truncate">{exp.company}</p>
-                <p className="text-xs text-gray-600 truncate">{exp.position}</p>
-                <p className="text-xs text-gray-500">{exp.start_date} – {endDisplay}</p>
+    <ul className="space-y-3">
+      {ordered.map((exp, index) => {
+        const endDisplay = exp.present ? "Present" : exp.end_date;
+        return (
+          <li
+            key={exp.id}
+            draggable={isAdmin}
+            onDragStart={(e) => isAdmin && e.dataTransfer.setData("text/plain", String(index))}
+            onDragOver={(e) => isAdmin && e.preventDefault()}
+            onDrop={(e) => {
+              if (!isAdmin) return;
+              const fromIndex = Number(e.dataTransfer.getData("text/plain"));
+              handleDrop(fromIndex, index);
+            }}
+            className={`group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/90 p-4 transition-all duration-200 shadow-sm hover:shadow-md ${
+              isAdmin ? "cursor-grab" : "cursor-default"
+            }`}
+          >
+            <div className="absolute left-3 top-0 bottom-0 w-[2px] bg-gradient-to-b from-blue-500/30 via-blue-400/30 to-indigo-400/30" aria-hidden />
+            <div className="flex items-start gap-4">
+              <img src={exp.image_url} alt={exp.company} className="w-12 h-12 rounded-xl object-cover shadow-sm border border-slate-200" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-semibold text-slate-900 truncate">{exp.company}</p>
+                  {isAdmin && <span className="text-[10px] uppercase tracking-[0.12em] text-blue-600 bg-blue-50 border border-blue-100 rounded-full px-2 py-0.5">draggable</span>}
+                </div>
+                <p className="text-xs text-slate-600 truncate">{exp.position}</p>
+                <p className="text-xs text-slate-500">{exp.start_date} – {endDisplay}</p>
+                {exp.description && (
+                  <p
+                    className="mt-2 text-sm text-slate-700 leading-relaxed"
+                    style={{
+                      display: "-webkit-box",
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: "vertical",
+                      overflow: "hidden",
+                    }}
+                  >
+                    {exp.description}
+                  </p>
+                )}
               </div>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-slate-600">
+              <span className="rounded-full bg-slate-50 border border-slate-200 px-2 py-1">Order {index + 1}</span>
+              {exp.present && <span className="rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100 px-2 py-1">Present</span>}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/static/anoweb-front/src/Pages/Home/LatestPostCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/LatestPostCard.tsx
@@ -20,10 +20,10 @@ function stripMarkdown(md: string): string {
 export default function LatestPostCard({ post, size = "compact" }: LatestPostCardProps) {
   if (!post) return null;
 
-  const titleLines   = size === "compact" ? 2 : 4;
+  const titleLines = size === "compact" ? 2 : 4;
   const previewLines = size === "compact" ? 3 : 5;
-  const pad          = size === "compact" ? "p-3.5 sm:p-4" : "p-4 sm:p-5";
-  const previewText  = stripMarkdown(post.content_md || "");
+  const pad = size === "compact" ? "p-4" : "p-5";
+  const previewText = stripMarkdown(post.content_md || "");
 
   const updatedStr = new Date(post.updated_at).toLocaleString(undefined, {
     year: "numeric",
@@ -34,31 +34,21 @@ export default function LatestPostCard({ post, size = "compact" }: LatestPostCar
   });
 
   return (
-    <div
-      className="relative w-full overflow-hidden rounded-2xl shadow-lg ring-1 ring-black/5 bg-white
-                 transition-transform duration-200 hover:scale-[1.01] hover:shadow-xl"
-      style={{ aspectRatio: "1 / 1" }}   // keeps it square
-    >
-      {/* top accent stripe */}
-      <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-blue-400 via-indigo-400 to-fuchsia-400 opacity-70" />
-
-      {/* Make the INNER container the grid so rows are guaranteed */}
+    <div className="relative w-full overflow-hidden rounded-2xl shadow-lg ring-1 ring-black/5 bg-white/90">
+      <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-indigo-500/10 to-fuchsia-500/10" aria-hidden />
       <Link
         to="/projects"
-        className={`block w-full h-full ${pad} grid min-h-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-2xl`}
-        style={{ gridTemplateRows: "auto auto 1fr auto" }}
+        className={`relative block w-full h-full ${pad} space-y-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-2xl`}
         aria-label={`Open latest post: ${post.name}`}
       >
-        {/* Row 1: badge */}
-        <div className="mb-1">
-          <span className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold
-                           bg-gradient-to-r from-blue-50 to-indigo-50 text-indigo-700 ring-1 ring-indigo-100">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold bg-white/80 text-indigo-700 ring-1 ring-indigo-100 shadow-sm">
             <span aria-hidden>🆕</span>
-            Latest&nbsp;Post
+            Latest Post
           </span>
+          <span className="text-[11px] text-slate-600">Updated {updatedStr}</span>
         </div>
 
-        {/* Row 2: title (never covered) */}
         <div className="relative z-10">
           <h3
             className="text-[15px] sm:text-base font-semibold text-gray-900 leading-5 sm:leading-6 tracking-tight"
@@ -76,10 +66,9 @@ export default function LatestPostCard({ post, size = "compact" }: LatestPostCar
           </h3>
         </div>
 
-        {/* Row 3: snippet (takes only leftover space) */}
-        <div className="relative min-h-0 overflow-hidden mt-1">
+        <div className="relative min-h-0 overflow-hidden">
           <p
-            className="text-[12.5px] sm:text-sm text-gray-700 leading-5"
+            className="text-[13px] sm:text-sm text-gray-700 leading-6"
             style={{
               display: "-webkit-box",
               WebkitLineClamp: previewLines,
@@ -91,15 +80,13 @@ export default function LatestPostCard({ post, size = "compact" }: LatestPostCar
           >
             {previewText}
           </p>
-          {/* fade lives inside snippet, low z-index */}
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-5 sm:h-6 bg-gradient-to-t from-white to-transparent z-0" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-white/90 to-transparent z-0" />
         </div>
 
-        {/* Row 4: footer — ALWAYS visible */}
         <div className="pt-1.5">
-          <p className="text-[11px] sm:text-xs text-gray-600 inline-flex items-center gap-1">
-            <span aria-hidden>🕒</span>
-            <span>Updated: {updatedStr}</span>
+          <p className="text-[11px] sm:text-xs text-slate-600 inline-flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-blue-500" aria-hidden />
+            Read inside Projects
           </p>
         </div>
       </Link>

--- a/static/anoweb-front/src/Pages/Home/ProfileCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/ProfileCard.tsx
@@ -6,29 +6,58 @@ type ProfileCardProps = {
 
 export default function ProfileCard({ profile }: ProfileCardProps) {
   if (!profile) {
-    return <div className="bg-white rounded-2xl shadow-lg p-6 w-full animate-pulse">Loading Profile...</div>;
+    return (
+      <div className="bg-white/80 rounded-3xl shadow-lg p-6 w-full border border-slate-200 animate-pulse h-[420px]" />
+    );
   }
 
   return (
-    <div className="bg-white rounded-2xl shadow-lg p-6 w-full">
-      <img
-        src="/image/profile-img.png"
-        alt="Profile"
-        className="mx-auto mb-4 rounded-lg shadow-md object-cover w-full max-w-[260px] h-[300px]"
-      />
-      <h1 className="text-2xl font-bold text-gray-800 mb-2">{profile.name}</h1>
-      <p className="text-gray-600 mb-4">{profile.bio}</p>
-      <div className="space-y-1 text-sm text-gray-700">
-        <p><span className="font-semibold">Email:</span> {profile.email}</p>
-        <p>
-          <span className="font-semibold">GitHub:</span>{" "}
-          <a href={profile.github} className="text-blue-600 hover:underline">Click</a>
-        </p>
-        <p>
-          <span className="font-semibold">LinkedIn:</span>{" "}
-          <a href={profile.linkedin} className="text-blue-600 hover:underline">Click</a>
-        </p>
+    <article className="relative overflow-hidden rounded-3xl bg-white/90 border border-slate-200 shadow-lg">
+      <div className="absolute inset-0 bg-gradient-to-br from-blue-500/10 via-blue-100/30 to-indigo-100/40" aria-hidden />
+      <div className="relative grid gap-6 md:grid-cols-[220px_1fr] p-6 md:p-8">
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative w-full max-w-[220px]">
+            <img
+              src="/image/profile-img.png"
+              alt="Profile"
+              className="w-full h-[260px] rounded-2xl object-cover shadow-md border border-slate-200"
+            />
+            <div className="absolute -bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 text-white px-3 py-1 text-xs font-semibold shadow-md">
+              {profile.name}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2 justify-center">
+            <a
+              href={`mailto:${profile.email}`}
+              className="chip-soft"
+            >
+              Email
+            </a>
+            <a href={profile.github} target="_blank" rel="noopener noreferrer" className="chip-soft">
+              GitHub
+            </a>
+            <a href={profile.linkedin} target="_blank" rel="noopener noreferrer" className="chip-soft">
+              LinkedIn
+            </a>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Profile</p>
+          <h2 className="text-2xl font-semibold text-slate-900">{profile.name}</h2>
+          <p className="text-slate-700 leading-relaxed whitespace-pre-line">{profile.bio}</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+            <div className="rounded-2xl bg-slate-50/80 border border-slate-200 p-3">
+              <p className="text-xs uppercase tracking-[0.12em] text-slate-500">Email</p>
+              <p className="font-semibold text-slate-900 break-all">{profile.email}</p>
+            </div>
+            <div className="rounded-2xl bg-slate-50/80 border border-slate-200 p-3">
+              <p className="text-xs uppercase tracking-[0.12em] text-slate-500">Networks</p>
+              <p className="font-semibold text-slate-900">GitHub & LinkedIn available</p>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
+    </article>
   );
 }

--- a/static/anoweb-front/src/Pages/Home/index.tsx
+++ b/static/anoweb-front/src/Pages/Home/index.tsx
@@ -15,73 +15,102 @@ export default function Home() {
 
   return (
     <div className="space-y-8">
-      <div className="flex items-center justify-between gap-4">
-        <div>
-          <p className="text-sm uppercase tracking-[0.18em] text-slate-500">Welcome</p>
-          <h1 className="text-3xl font-semibold text-slate-900">Home</h1>
-        </div>
-        <span className="rounded-full bg-blue-50 text-blue-700 px-4 py-2 text-sm font-medium">Google-inspired layout</span>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)_340px] items-stretch">
-        <div className="flex flex-col h-full gap-4">
-          <ProfileCard profile={profile} />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 w-full">
-              <h2 className="text-lg font-semibold text-slate-900 mb-2 text-center">Admin Status</h2>
-              {isAdmin ? (
-                <div className="flex flex-col items-center text-center space-y-2">
-                  <span className="text-3xl">🛡️</span>
-                  <p className="text-emerald-700 font-semibold">You are now in Admin Mode!</p>
-                </div>
-              ) : (
-                <div className="flex flex-col items-center text-center space-y-2">
-                  <span className="text-3xl">🙅</span>
-                  <p className="text-rose-600 font-semibold">No admin rights for you!</p>
-                </div>
+      <section className="rounded-3xl bg-white/80 shadow-lg border border-slate-200/80 overflow-hidden relative">
+        <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-[#e8f0fe]/60 to-green-100/60" aria-hidden />
+        <div className="relative grid gap-8 md:grid-cols-[1.2fr_1fr] p-6 md:p-8 lg:p-10">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-600">Overview</p>
+            <h1 className="text-3xl md:text-4xl font-semibold text-slate-900">
+              Building with clarity and Google-inspired polish.
+            </h1>
+            <p className="text-slate-700 leading-relaxed max-w-3xl">
+              This console-style dashboard surfaces my profile, education, work history, and the latest things I&apos;ve been writing
+              about. Everything is powered by the live APIs that back this site.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/projects"
+                className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700"
+              >
+                View projects
+              </Link>
+              <a
+                href="https://drive.google.com/file/d/1lJQSIysTrcrDtCgAK0koo-gIb0rhaJAK/view?usp=sharing"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-slate-800 border border-slate-200 shadow-sm hover:bg-slate-50"
+              >
+                Download CV
+              </a>
+              {isAdmin && (
+                <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700 border border-emerald-200">
+                  <span className="h-2.5 w-2.5 rounded-full bg-emerald-500" /> Admin mode
+                </span>
               )}
             </div>
-
-            <LatestPostCard post={latestPost} size="compact" />
           </div>
-        </div>
-
-        <div className="flex flex-col h-full gap-3">
-          <div className="basis-0 flex-[2] flex [&>*]:h-full">
-            <EducationCard education={education} />
-          </div>
-
-          <div className="basis-0 flex-[3] flex [&>*]:h-full">
-            <ExperienceCard experience={experience} setExperience={setExperience} />
-          </div>
-        </div>
-
-        <div className="flex flex-col h-full gap-4">
-          <Link
-            to="/projects"
-            className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 w-full transition-transform duration-150 hover:scale-[1.01] hover:shadow-md no-underline flex flex-1"
-          >
-            <div className="m-auto text-center flex flex-col items-center">
-              <h2 className="text-lg font-semibold text-slate-900 mb-3">Projects</h2>
-              <span className="text-4xl mb-2">🚀</span>
-              <p className="text-slate-600 max-w-[22ch]">Explore my portfolio of work and personal projects.</p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <LatestPostCard post={latestPost} size="default" />
+            <div className="rounded-2xl bg-white/90 border border-slate-200 shadow-sm p-4 flex flex-col justify-between">
+              <div className="flex items-center gap-3">
+                <div className="h-10 w-10 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 text-white grid place-items-center font-semibold">
+                  API
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Status</p>
+                  <p className="font-semibold text-slate-900">Live portfolio endpoints</p>
+                </div>
+              </div>
+              <p className="text-sm text-slate-700 mt-3">
+                Data on this page comes directly from the Go backend: profile, education, experiences, projects, and posts.
+              </p>
             </div>
-          </Link>
-
-          <a
-            href="https://drive.google.com/file/d/1lJQSIysTrcrDtCgAK0koo-gIb0rhaJAK/view?usp=sharing"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 w-full transition-transform duration-150 hover:scale-[1.01] hover:shadow-md no-underline flex"
-          >
-            <div className="m-auto text-center flex flex-col items-center">
-              <h2 className="text-lg font-semibold text-slate-900 mb-3">View My CV</h2>
-              <span className="text-4xl mb-2">📄</span>
-              <p className="text-slate-600 max-w-[24ch]">Download my resume to explore my experience and skills in depth.</p>
-            </div>
-          </a>
+          </div>
         </div>
-      </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr] items-start">
+        <ProfileCard profile={profile} />
+        <EducationCard education={education} />
+      </section>
+
+      <section className="rounded-3xl bg-white/80 shadow-lg border border-slate-200/80 p-6 md:p-8">
+        <div className="flex items-center justify-between gap-4 mb-6">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Experience</p>
+            <h2 className="text-2xl font-semibold text-slate-900">Career path</h2>
+          </div>
+          <span className="rounded-full bg-blue-50 text-blue-700 px-3 py-1 text-xs font-semibold border border-blue-100">Drag to reprioritise (admin)</span>
+        </div>
+        <ExperienceCard experience={experience} setExperience={setExperience} />
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <Link
+          to="/projects"
+          className="group relative overflow-hidden rounded-3xl bg-white shadow-lg border border-slate-200/80 p-6 md:p-8 flex items-center gap-4"
+        >
+          <div className="absolute inset-0 bg-gradient-to-r from-blue-500/10 via-indigo-500/10 to-purple-500/10 opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden />
+          <div className="relative h-12 w-12 rounded-2xl bg-blue-600 text-white grid place-items-center text-xl font-semibold shadow-md">↗</div>
+          <div className="relative">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Navigate</p>
+            <h3 className="text-xl font-semibold text-slate-900">Projects workspace</h3>
+            <p className="text-sm text-slate-700 mt-1">Review projects, read posts, and manage content from a Google-like console.</p>
+          </div>
+        </Link>
+        <a
+          href="mailto:zhouzhouzhang@gmail.com"
+          className="group relative overflow-hidden rounded-3xl bg-white shadow-lg border border-slate-200/80 p-6 md:p-8 flex items-center gap-4"
+        >
+          <div className="absolute inset-0 bg-gradient-to-r from-green-500/10 via-emerald-500/10 to-blue-500/10 opacity-0 group-hover:opacity-100 transition-opacity" aria-hidden />
+          <div className="relative h-12 w-12 rounded-2xl bg-emerald-600 text-white grid place-items-center text-xl font-semibold shadow-md">✉</div>
+          <div className="relative">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Contact</p>
+            <h3 className="text-xl font-semibold text-slate-900">Get in touch</h3>
+            <p className="text-sm text-slate-700 mt-1">Reach out for collaboration, consulting, or a quick coffee chat.</p>
+          </div>
+        </a>
+      </section>
     </div>
   );
 }

--- a/static/anoweb-front/src/Pages/Projects/PostCardRail.tsx
+++ b/static/anoweb-front/src/Pages/Projects/PostCardRail.tsx
@@ -87,22 +87,27 @@ export function PostCardRail({
   };
 
   return (
-    <section className="h-60 shrink-0" style={{ perspective: "1500px" }}>
-      <div
-        ref={railRef}
-        className="h-full flex items-center gap-6 overflow-x-auto snap-x snap-mandatory custom-scrollbar py-2"
-      >
-        <div className="shrink-0 basis-[calc(50%-8rem)]" />
+    <section className="rounded-3xl bg-white/90 border border-slate-200 shadow-lg p-4">
+      <div className="flex items-center justify-between mb-3 px-1">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Posts</p>
+          <h3 className="text-lg font-semibold text-slate-900">Project updates</h3>
+        </div>
         {isAdmin && (
           <button
             onClick={onOpenCreateModal}
-            className="shrink-0 w-64 h-52 snap-center rounded-2xl p-6 cursor-pointer bg-blue-500/80 hover:bg-blue-500/95 text-white flex items-center justify-center text-2xl font-semibold transition-all duration-300 hover:shadow-lg hover:shadow-blue-200/60"
+            className="rounded-full bg-blue-600 text-white px-3 py-1.5 text-xs font-semibold shadow-sm hover:bg-blue-700"
           >
-            + New Post
+            + New post
           </button>
         )}
+      </div>
+      <div
+        ref={railRef}
+        className="h-60 flex items-center gap-4 overflow-x-auto snap-x snap-mandatory custom-scrollbar pb-2"
+      >
         {isLoading ? (
-          <p className="text-slate-500">Loading Posts...</p>
+          <p className="text-slate-500 px-4">Loading Posts...</p>
         ) : posts.length > 0 ? (
           sortedPosts.map((post) => (
             <div
@@ -111,41 +116,42 @@ export function PostCardRail({
                 cardRefs.current[post.id] = el;
               }}
               onClick={() => handleCardClick(post)}
-              className={`
-                  shrink-0 w-64 h-52 snap-center rounded-2xl p-6 cursor-pointer
-                  bg-white/80 hover:bg-white/95 backdrop-blur-md border border-blue-200/50
-                  shadow-md flex flex-col justify-between
-                  transition-shadow duration-300 hover:shadow-lg hover:shadow-blue-200/60
-                  relative
-                  ${focusedPostId === post.id ? "focused-card" : ""}
-                `}
+              className={`shrink-0 w-64 h-full snap-start rounded-2xl border p-4 cursor-pointer bg-white/80 shadow-sm hover:shadow-md transition-all duration-200 relative ${
+                focusedPostId === post.id ? "focused-card" : "border-slate-200"
+              }`}
             >
-              <h3 className="font-semibold text-slate-800 line-clamp-4 text-base">
-                {post.name}
-              </h3>
-              <p className="text-xs text-slate-500 mt-2">
-                Updated: {new Date(post.updated_at).toLocaleDateString()}
-              </p>
-              {isAdmin && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDeletePost(post.id);
-                  }}
-                  className="absolute top-2 right-2 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center"
-                  aria-label="Delete post"
-                >
-                  X
-                </button>
-              )}
+              <div className="flex items-start gap-2">
+                <div className="h-8 w-8 rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white grid place-items-center text-sm font-semibold">
+                  MD
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 line-clamp-3">{post.name}</p>
+                  <p className="text-[11px] text-slate-600">Updated {new Date(post.updated_at).toLocaleDateString()}</p>
+                </div>
+              </div>
+              <div className="absolute bottom-3 left-4 right-4 flex items-center justify-between text-[11px] text-slate-600">
+                <span className="inline-flex items-center gap-1">
+                  <span className="h-2 w-2 rounded-full bg-blue-500" />
+                  Tap to open
+                </span>
+                {isAdmin && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDeletePost(post.id);
+                    }}
+                    className="text-rose-600 hover:text-rose-700 font-semibold"
+                    aria-label="Delete post"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
             </div>
           ))
         ) : (
-          <div className="text-center w-full text-slate-500">
-            No posts found for this project.
-          </div>
+          <div className="text-center w-full text-slate-500 px-4">No posts found for this project.</div>
         )}
-        <div className="shrink-0 basis-[calc(50%-8rem)]" />
       </div>
     </section>
   );

--- a/static/anoweb-front/src/Pages/Projects/ProjectList.tsx
+++ b/static/anoweb-front/src/Pages/Projects/ProjectList.tsx
@@ -1,6 +1,6 @@
 // src/components/ProjectPage/ProjectList.tsx
 
-import { useRef, useContext } from "react";
+import { useContext } from "react";
 import { type Project } from "./types";
 import { AdminContext } from "../../Contexts/admin_context";
 
@@ -9,7 +9,6 @@ type ProjectListProps = {
   selectedProjectId: number | null;
   isLoading: boolean;
   onSelectProject: (id: number) => void;
-  isOpen: boolean;
   onOpenCreateModal: () => void;
 };
 
@@ -18,59 +17,58 @@ export default function ProjectList({
   selectedProjectId,
   isLoading,
   onSelectProject,
-  isOpen,
   onOpenCreateModal,
 }: ProjectListProps) {
-  const leftRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<Record<number, HTMLDivElement | null>>({});
   const { isAdmin } = useContext(AdminContext);
 
   return (
-    <aside
-      ref={leftRef}
-      className={`
-        w-72 h-full flex flex-col items-stretch pt-10 px-4 custom-scrollbar
-        transition-transform duration-300 ease-in-out 
-        md:flex md:static md:translate-x-0 md:bg-transparent md:border-none md:shadow-none md:w-72
-        fixed top-0 left-0 z-40 bg-white/80 backdrop-blur-lg border-r border-gray-200 shadow-xl
-        ${isOpen ? "translate-x-0" : "-translate-x-full"}
-      `}
-    >
-      {isAdmin && (
-        <div className="px-4 pb-6 border-b border-slate-200/80">
+    <aside className="rounded-3xl bg-white/90 border border-slate-200 shadow-lg p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Projects</p>
+          <h2 className="text-lg font-semibold text-slate-900">Navigation rail</h2>
+        </div>
+        {isAdmin && (
           <button
             onClick={onOpenCreateModal}
-            className="w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-blue-600 transition-colors"
+            className="rounded-full bg-blue-600 text-white px-3 py-1.5 text-xs font-semibold shadow-sm hover:bg-blue-700"
           >
-            + New Project
+            + New
           </button>
-        </div>
-      )}
+        )}
+      </div>
 
-      <div className="flex-1 overflow-y-auto custom-scrollbar">
-        <div className="h-1/2" />
+      <div className="space-y-2 max-h-[520px] overflow-auto custom-scrollbar pr-1">
         {isLoading ? (
-          <p className="text-center text-slate-500">Loading Projects...</p>
+          <p className="text-center text-slate-500">Loading projects...</p>
+        ) : projects.length === 0 ? (
+          <p className="text-center text-slate-500">No projects yet.</p>
         ) : (
           projects.map((p) => (
-            <div
+            <button
               key={p.id}
-              ref={(el) => {
-                itemRefs.current[p.id] = el;
-              }}
               onClick={() => onSelectProject(p.id)}
-              className={[
-                "snap-center my-3 py-3 cursor-pointer text-center transition-all duration-300 mx-auto w-full text-lg",
+              className={`w-full text-left rounded-2xl border px-4 py-3 transition-all duration-200 shadow-sm hover:shadow-md ${
                 p.id === selectedProjectId
-                  ? "font-bold scale-110 text-blue-400"
-                  : "font-normal text-slate-600 hover:text-blue-300",
-              ].join(" ")}
+                  ? "border-blue-200 bg-blue-50 text-blue-900"
+                  : "border-slate-200 bg-white/80 text-slate-800 hover:bg-slate-50"
+              }`}
             >
-              {p.name}
-            </div>
+              <p className="text-sm font-semibold leading-tight">{p.name}</p>
+              <p
+                className="text-[12px] text-slate-600"
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                {p.description || "No description"}
+              </p>
+            </button>
           ))
         )}
-        <div className="h-1/2" />
       </div>
     </aside>
   );

--- a/static/anoweb-front/src/Pages/Projects/index.tsx
+++ b/static/anoweb-front/src/Pages/Projects/index.tsx
@@ -1,6 +1,5 @@
 // src/components/ProjectPage/index.tsx
 
-import { useState } from "react";
 import { useProjectData } from "./useProjectData";
 import ProjectList from "./ProjectList";
 import { ProjectDetails } from "./ProjectDetails";
@@ -8,7 +7,6 @@ import { PostCardRail } from "./PostCardRail";
 import CreateProjectModal from "./CreateProjectModal";
 import CreatePostModal from "./CreatePostModal";
 
-// CSS for scrollbar and markdown styling
 const styles = `
   .custom-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
   .custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
@@ -17,19 +15,10 @@ const styles = `
   .custom-scrollbar { scrollbar-width: thin; scrollbar-color: rgba(0, 0, 0, 0.2) transparent; }
   .prose { max-width: 100%; }
   .prose h1, .prose h2, .prose h3 { color: #334155; }
-  .prose a { color: #2563eb; } /* Blue-600 */
-  .prose a:hover { color: #1d4ed8; } /* Blue-700 */
-  .focused-card { box-shadow: 0 0 20px rgba(59, 130, 246, 0.7); }
+  .prose a { color: #2563eb; }
+  .prose a:hover { color: #1d4ed8; }
+  .focused-card { box-shadow: 0 0 18px rgba(66, 133, 244, 0.35); }
 `;
-
-// A simple hamburger menu icon component
-function MenuIcon() {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-    </svg>
-  );
-}
 
 export default function ProjectPage() {
   const {
@@ -52,67 +41,66 @@ export default function ProjectPage() {
     handleDeletePost,
   } = useProjectData();
 
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-
   return (
     <>
       <style>{styles}</style>
-      <div className="min-h-screen h-screen w-full overflow-hidden flex relative">
-
-        {/* Mobile Menu Button */}
-        <button
-          onClick={() => setIsSidebarOpen(true)}
-          className="md:hidden fixed top-4 left-4 z-50 p-2 bg-white/70 backdrop-blur-sm rounded-md shadow-md text-slate-700"
-          aria-label="Open menu"
-        >
-          <MenuIcon />
-        </button>
-
-        {/* Mobile Overlay */}
-        {isSidebarOpen && (
-          <div
-            className="md:hidden fixed inset-0 bg-black/30 z-30"
-            onClick={() => setIsSidebarOpen(false)}
-          />
-        )}
-
-        {/* Left Sidebar */}
-        <ProjectList
-          projects={projects}
-          selectedProjectId={selectedProjectId}
-          isLoading={isLoadingProjects}
-          onSelectProject={(id) => {
-            setSelectedProjectId(id);
-            setIsSidebarOpen(false); // Auto-close sidebar on selection
-          }}
-          isOpen={isSidebarOpen}
-          onOpenCreateModal={openCreateModal}
-        />
-
-        {/* Main Content Area */}
-        <main className="flex-1 flex flex-col p-4 md:p-6 overflow-hidden">
-          {selectedProject ? (
-            <>
-              <ProjectDetails
-                project={selectedProject}
-                onProjectUpdate={refreshProjects}
-              />
-              <PostCardRail
-                posts={posts}
-                isLoading={isLoadingPosts}
-                onViewPost={handleViewPost}
-                onOpenCreateModal={openCreatePostModal}
-                onDeletePost={handleDeletePost}
-              />
-            </>
-          ) : (
-            <div className="flex items-center justify-center h-full text-slate-500">
-              {isLoadingProjects ? "Loading..." : "Select a project to see details."}
+      <div className="space-y-6">
+        <section className="rounded-3xl bg-white/90 border border-slate-200 shadow-lg overflow-hidden relative">
+          <div className="absolute inset-0 bg-gradient-to-r from-[#e8f0fe] via-white to-[#e6f4ea]" aria-hidden />
+          <div className="relative p-6 md:p-8 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Projects</p>
+              <h1 className="text-3xl font-semibold text-slate-900">Workspace</h1>
+              <p className="text-slate-700 mt-1 max-w-3xl">
+                Browse all portfolio projects, open detailed posts in the markdown reader, and manage content through the live API.
+              </p>
             </div>
-          )}
-        </main>
+            <div className="flex flex-wrap gap-2">
+              <span className="rounded-full bg-blue-50 text-blue-700 border border-blue-100 px-3 py-1 text-xs font-semibold">
+                {projects.length} projects
+              </span>
+              <span className="rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100 px-3 py-1 text-xs font-semibold">
+                {posts.length} posts
+              </span>
+              <button
+                onClick={openCreateModal}
+                className="rounded-full bg-blue-600 text-white px-4 py-2 text-sm font-semibold shadow-sm hover:bg-blue-700"
+              >
+                New project
+              </button>
+            </div>
+          </div>
+        </section>
 
-        {/* Create Project Modal (conditionally rendered) */}
+        <div className="grid gap-6 lg:grid-cols-[320px_1fr] items-start">
+          <ProjectList
+            projects={projects}
+            selectedProjectId={selectedProjectId}
+            isLoading={isLoadingProjects}
+            onSelectProject={setSelectedProjectId}
+            onOpenCreateModal={openCreateModal}
+          />
+
+          <div className="space-y-5">
+            {selectedProject ? (
+              <>
+                <ProjectDetails project={selectedProject} onProjectUpdate={refreshProjects} />
+                <PostCardRail
+                  posts={posts}
+                  isLoading={isLoadingPosts}
+                  onViewPost={handleViewPost}
+                  onOpenCreateModal={openCreatePostModal}
+                  onDeletePost={handleDeletePost}
+                />
+              </>
+            ) : (
+              <div className="rounded-3xl border border-dashed border-slate-300 bg-white/80 shadow-inner p-10 text-center text-slate-500">
+                {isLoadingProjects ? "Loading projects..." : "Select a project from the left to view details."}
+              </div>
+            )}
+          </div>
+        </div>
+
         {isCreateModalOpen && (
           <CreateProjectModal
             onClose={closeCreateModal}
@@ -123,7 +111,6 @@ export default function ProjectPage() {
           />
         )}
 
-        {/* Create Post Modal (conditionally rendered) */}
         {isCreatePostModalOpen && selectedProjectId && (
           <CreatePostModal
             onClose={closeCreatePostModal}

--- a/static/anoweb-front/src/main.tsx
+++ b/static/anoweb-front/src/main.tsx
@@ -11,11 +11,16 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <BrowserRouter>
       <AdminProvider>
         <MarkdownReaderProvider>
-          <div className="min-h-screen w-full bg-[#f5f7fb] text-slate-900">
-            <Navbar />
-            <main className="mx-auto max-w-6xl px-4 pb-12 pt-6 md:pt-10 md:px-8">
-              <AppRouter />
-            </main>
+          <div className="min-h-screen w-full bg-gradient-to-br from-[#e8f0fe] via-[#f5f7fb] to-[#e8eaed] text-slate-900">
+            <div className="absolute inset-0 pointer-events-none opacity-60" aria-hidden>
+              <div className="mx-auto max-w-6xl h-full bg-[radial-gradient(circle_at_10%_20%,rgba(66,133,244,0.12),transparent_25%),radial-gradient(circle_at_90%_20%,rgba(52,168,83,0.12),transparent_23%),radial-gradient(circle_at_30%_80%,rgba(244,180,0,0.1),transparent_20%),radial-gradient(circle_at_80%_70%,rgba(234,67,53,0.12),transparent_24%)]" />
+            </div>
+            <div className="relative">
+              <Navbar />
+              <main className="mx-auto max-w-6xl px-4 pb-14 pt-6 md:pt-10 md:px-8">
+                <AppRouter />
+              </main>
+            </div>
           </div>
         </MarkdownReaderProvider>
       </AdminProvider>

--- a/static/anoweb-front/src/style.css
+++ b/static/anoweb-front/src/style.css
@@ -3,6 +3,14 @@
 @import "katex/dist/katex.min.css";
 @import "highlight.js/styles/github.css";
 
+.nav-chip {
+  @apply inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-white transition-colors;
+}
+
+.chip-soft {
+  @apply inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs font-semibold text-slate-800 shadow-sm hover:bg-slate-50;
+}
+
 /* —— Editor toolbar tiny button —— */
 .btn-sm {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Redesign the main shell and navigation with Google-inspired gradients, soft surface chips, and admin indicators.
- Rebuild the home dashboard with new profile, education, experience, and latest post panels tied to backend APIs.
- Refresh the projects workspace with card-based navigation, updated post rail, and supporting styling utilities.

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acb99dd608332bc27d28572d9438b)