### PR TITLE
Streamline overview and clean project controls

### DIFF
--- a/static/anoweb-front/src/Pages/Home/index.tsx
+++ b/static/anoweb-front/src/Pages/Home/index.tsx
@@ -21,11 +21,11 @@ export default function Home() {
           <div className="space-y-4">
             <p className="text-xs uppercase tracking-[0.2em] text-slate-600">Overview</p>
             <h1 className="text-3xl md:text-4xl font-semibold text-slate-900">
-              Building with clarity and Google-inspired polish.
+              Clarity-first, Google-inspired portfolio console.
             </h1>
             <p className="text-slate-700 leading-relaxed max-w-3xl">
-              This console-style dashboard surfaces my profile, education, work history, and the latest things I&apos;ve been writing
-              about. Everything is powered by the live APIs that back this site.
+              A concise hub for profile, education, experience, and the newest writing pulled straight from the live portfolio
+              API—built to be skimmable and fast.
             </p>
             <div className="flex flex-wrap gap-3">
               <Link
@@ -80,7 +80,9 @@ export default function Home() {
             <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Experience</p>
             <h2 className="text-2xl font-semibold text-slate-900">Career path</h2>
           </div>
-          <span className="rounded-full bg-blue-50 text-blue-700 px-3 py-1 text-xs font-semibold border border-blue-100">Drag to reprioritise (admin)</span>
+          {isAdmin && (
+            <span className="rounded-full bg-blue-50 text-blue-700 px-3 py-1 text-xs font-semibold border border-blue-100">Drag to reprioritise (admin)</span>
+          )}
         </div>
         <ExperienceCard experience={experience} setExperience={setExperience} />
       </section>

--- a/static/anoweb-front/src/Pages/Projects/CreatePostModal.tsx
+++ b/static/anoweb-front/src/Pages/Projects/CreatePostModal.tsx
@@ -128,7 +128,7 @@ export default function CreatePostModal({
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
-              className="mt-1 w-full rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              className="mt-1 w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
             />
           </div>
 

--- a/static/anoweb-front/src/Pages/Projects/CreateProjectModal.tsx
+++ b/static/anoweb-front/src/Pages/Projects/CreateProjectModal.tsx
@@ -84,15 +84,34 @@ export default function CreateProjectModal({ onClose, onSuccess }: CreateProject
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-slate-700">Project Name</label>
-            <input type="text" id="name" value={name} onChange={(e) => setName(e.target.value)} required className="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            <input
+              type="text"
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            />
           </div>
           <div>
             <label htmlFor="description" className="block text-sm font-medium text-slate-700">Description</label>
-            <textarea id="description" value={description} onChange={(e) => setDescription(e.target.value)} rows={4} className="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            <textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            />
           </div>
           <div>
             <label htmlFor="link" className="block text-sm font-medium text-slate-700">Project Link</label>
-            <input type="url" id="link" value={link} onChange={(e) => setLink(e.target.value)} className="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            <input
+              type="url"
+              id="link"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-700">Cover Image</label>

--- a/static/anoweb-front/src/Pages/Projects/ProjectDetails.tsx
+++ b/static/anoweb-front/src/Pages/Projects/ProjectDetails.tsx
@@ -76,8 +76,14 @@ export function ProjectDetails({ project, onProjectUpdate }: ProjectDetailsProps
         <form onSubmit={handleSubmit} className="flex flex-col md:flex-row gap-8 h-full">
           {/* Left side: Image Upload */}
           <div className="w-full md:w-1/3 flex flex-col items-center gap-4">
-            <img src={formData.image_url} alt="Project preview" className="w-full h-auto object-cover rounded-2xl shadow-md"/>
-            <input type="file" accept="image/*" onChange={handleImageUpload} disabled={isUploading} className="text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"/>
+            <img src={formData.image_url} alt="Project preview" className="w-full h-auto object-cover rounded-2xl shadow-md" />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleImageUpload}
+              disabled={isUploading}
+              className="text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+            />
             {isUploading && <p className="text-sm text-slate-500">Uploading...</p>}
           </div>
 
@@ -85,15 +91,33 @@ export function ProjectDetails({ project, onProjectUpdate }: ProjectDetailsProps
           <div className="flex-1 flex flex-col gap-4 overflow-y-auto custom-scrollbar">
             <div>
               <label htmlFor="name" className="block text-sm font-medium text-slate-700">Name</label>
-              <input type="text" id="name" value={formData.name} onChange={(e) => setFormData({...formData, name: e.target.value})} className="mt-1 block w-full rounded-md border-slate-300"/>
+              <input
+                type="text"
+                id="name"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              />
             </div>
             <div>
               <label htmlFor="description" className="block text-sm font-medium text-slate-700">Description</label>
-              <textarea id="description" value={formData.description} onChange={(e) => setFormData({...formData, description: e.target.value})} rows={5} className="mt-1 block w-full rounded-md border-slate-300"/>
+              <textarea
+                id="description"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={5}
+                className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              />
             </div>
             <div>
               <label htmlFor="link" className="block text-sm font-medium text-slate-700">Link</label>
-              <input type="url" id="link" value={formData.link} onChange={(e) => setFormData({...formData, link: e.target.value})} className="mt-1 block w-full rounded-md border-slate-300"/>
+              <input
+                type="url"
+                id="link"
+                value={formData.link}
+                onChange={(e) => setFormData({ ...formData, link: e.target.value })}
+                className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              />
             </div>
             {error && <p className="text-sm text-red-600">{error}</p>}
             <div className="flex justify-end items-center gap-4 mt-auto pt-4">
@@ -113,7 +137,7 @@ export function ProjectDetails({ project, onProjectUpdate }: ProjectDetailsProps
     <section className="flex-1 rounded-3xl bg-white/70 backdrop-blur-lg overflow-hidden border border-blue-200/50 flex flex-col md:flex-row gap-8 p-8 mb-6 min-h-0 shadow-lg relative">
       {/* Edit button for admins */}
       {isAdmin && (
-        <button 
+        <button
           onClick={() => setIsEditing(true)}
           className="absolute top-4 right-4 bg-white/80 hover:bg-white text-slate-600 font-semibold py-2 px-4 rounded-lg shadow text-sm transition-colors"
         >

--- a/static/anoweb-front/src/Pages/Projects/ProjectList.tsx
+++ b/static/anoweb-front/src/Pages/Projects/ProjectList.tsx
@@ -9,7 +9,6 @@ type ProjectListProps = {
   selectedProjectId: number | null;
   isLoading: boolean;
   onSelectProject: (id: number) => void;
-  onOpenCreateModal: () => void;
 };
 
 export default function ProjectList({
@@ -17,7 +16,6 @@ export default function ProjectList({
   selectedProjectId,
   isLoading,
   onSelectProject,
-  onOpenCreateModal,
 }: ProjectListProps) {
   const { isAdmin } = useContext(AdminContext);
 
@@ -29,12 +27,9 @@ export default function ProjectList({
           <h2 className="text-lg font-semibold text-slate-900">Navigation rail</h2>
         </div>
         {isAdmin && (
-          <button
-            onClick={onOpenCreateModal}
-            className="rounded-full bg-blue-600 text-white px-3 py-1.5 text-xs font-semibold shadow-sm hover:bg-blue-700"
-          >
-            + New
-          </button>
+          <span className="rounded-full bg-blue-50 text-blue-700 border border-blue-100 px-3 py-1 text-[11px] font-semibold">
+            Admin tools
+          </span>
         )}
       </div>
 

--- a/static/anoweb-front/src/Pages/Projects/index.tsx
+++ b/static/anoweb-front/src/Pages/Projects/index.tsx
@@ -1,11 +1,13 @@
 // src/components/ProjectPage/index.tsx
 
+import { useContext } from "react";
 import { useProjectData } from "./useProjectData";
 import ProjectList from "./ProjectList";
 import { ProjectDetails } from "./ProjectDetails";
 import { PostCardRail } from "./PostCardRail";
 import CreateProjectModal from "./CreateProjectModal";
 import CreatePostModal from "./CreatePostModal";
+import { AdminContext } from "../../Contexts/admin_context";
 
 const styles = `
   .custom-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
@@ -40,6 +42,7 @@ export default function ProjectPage() {
     refreshPosts,
     handleDeletePost,
   } = useProjectData();
+  const { isAdmin } = useContext(AdminContext);
 
   return (
     <>
@@ -47,27 +50,30 @@ export default function ProjectPage() {
       <div className="space-y-6">
         <section className="rounded-3xl bg-white/90 border border-slate-200 shadow-lg overflow-hidden relative">
           <div className="absolute inset-0 bg-gradient-to-r from-[#e8f0fe] via-white to-[#e6f4ea]" aria-hidden />
-          <div className="relative p-6 md:p-8 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div>
+          <div className="relative p-6 md:p-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-2">
               <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Projects</p>
               <h1 className="text-3xl font-semibold text-slate-900">Workspace</h1>
               <p className="text-slate-700 mt-1 max-w-3xl">
-                Browse all portfolio projects, open detailed posts in the markdown reader, and manage content through the live API.
+                Skim projects and their posts in one place, with a focused reader for the details.
               </p>
             </div>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <span className="rounded-full bg-blue-50 text-blue-700 border border-blue-100 px-3 py-1 text-xs font-semibold">
                 {projects.length} projects
               </span>
               <span className="rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100 px-3 py-1 text-xs font-semibold">
                 {posts.length} posts
               </span>
-              <button
-                onClick={openCreateModal}
-                className="rounded-full bg-blue-600 text-white px-4 py-2 text-sm font-semibold shadow-sm hover:bg-blue-700"
-              >
-                New project
-              </button>
+              {isAdmin && (
+                <button
+                  onClick={openCreateModal}
+                  className="inline-flex items-center gap-2 rounded-full bg-blue-600 text-white px-4 py-2 text-sm font-semibold shadow-sm hover:bg-blue-700"
+                >
+                  <span aria-hidden>＋</span>
+                  New project
+                </button>
+              )}
             </div>
           </div>
         </section>
@@ -78,7 +84,6 @@ export default function ProjectPage() {
             selectedProjectId={selectedProjectId}
             isLoading={isLoadingProjects}
             onSelectProject={setSelectedProjectId}
-            onOpenCreateModal={openCreateModal}
           />
 
           <div className="space-y-5">


### PR DESCRIPTION
## Summary
- Shortened the home overview copy and gated the drag-to-reorder hint to admins only
- Consolidated project workspace actions, removing duplicate create buttons and making the admin CTA consistent
- Refined project edit/create form styling with proper borders and cleaned up button styling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad1f123548332b327a9b2262af70d)