### PR TITLE
Improve markdown workspace and home UI

### DIFF
--- a/static/anoweb-front/src/Pages/Home/EducationCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/EducationCard.tsx
@@ -4,9 +4,59 @@ type EducationCardProps = {
   education: Education[];
 };
 
-export default function EducationCard({ education }: EducationCardProps) {
-  if (education.length === 0) return null;
+function formatRange(start: string, end: string) {
+  const normalize = (value: string) => value?.split("T")[0] || "";
+  if (!start && !end) return "Date not provided";
+  return `${normalize(start)} – ${normalize(end) || "Present"}`;
+}
 
+function EducationRow({ edu }: { edu: Education }) {
+  return (
+    <li className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-r from-white to-slate-50 hover:from-indigo-50/50 hover:to-white p-4 transition-all duration-200 shadow-sm">
+      <div className="flex items-start gap-4">
+        <div className="shrink-0">
+          <img
+            src={edu.image_url}
+            alt={edu.school}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = "https://via.placeholder.com/64?text=Edu";
+            }}
+            className="w-12 h-12 rounded-lg object-cover shadow-sm border border-slate-200 bg-white"
+          />
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-semibold text-slate-900 truncate">{edu.school}</p>
+            <span className="rounded-full bg-slate-50 border border-slate-200 text-[11px] px-2 py-0.5 text-slate-700">
+              {formatRange(edu.start_date, edu.end_date)}
+            </span>
+          </div>
+          <p className="text-xs text-slate-600 truncate">{edu.degree}</p>
+          <div className="flex items-center gap-3 text-xs text-slate-600">
+            {edu.link ? (
+              <a
+                href={edu.link}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-indigo-700 hover:text-indigo-800 font-semibold"
+              >
+                View credential
+                <span aria-hidden>↗</span>
+              </a>
+            ) : (
+              <span className="inline-flex items-center gap-1 text-slate-500">
+                <span className="h-2 w-2 rounded-full bg-slate-300" aria-hidden />
+                No link provided
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default function EducationCard({ education }: EducationCardProps) {
   return (
     <article className="bg-white/90 rounded-3xl shadow-lg border border-slate-200 p-6 md:p-8 h-full flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -15,30 +65,20 @@ export default function EducationCard({ education }: EducationCardProps) {
           <h2 className="text-xl font-semibold text-slate-900">Academic trail</h2>
         </div>
         <span className="rounded-full bg-indigo-50 text-indigo-700 px-3 py-1 text-xs font-semibold border border-indigo-100">
-          {education.length} entries
+          {education.length} {education.length === 1 ? "entry" : "entries"}
         </span>
       </div>
-      <ul className="space-y-3 flex-1 overflow-auto scrollbar-clear">
-        {education.map((edu) => (
-          <a
-            key={edu.id}
-            className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-r from-white to-slate-50 hover:from-indigo-50/50 hover:to-white p-4 transition-all duration-200 shadow-sm cursor-pointer"
-            href={edu.link}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <div className="flex items-center gap-4">
-              <img src={edu.image_url} alt={edu.school} className="w-12 h-12 rounded-lg object-cover shadow-sm border border-slate-200" />
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold text-slate-900 truncate">{edu.school}</p>
-                <p className="text-xs text-slate-600 truncate">{edu.degree}</p>
-                <p className="text-xs text-slate-500">{edu.start_date} – {edu.end_date}</p>
-              </div>
-              <div className="hidden sm:block text-[11px] font-semibold text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-full px-3 py-1">Open</div>
-            </div>
-          </a>
-        ))}
-      </ul>
+      {education.length === 0 ? (
+        <div className="flex-1 rounded-2xl border border-dashed border-slate-300 bg-slate-50/50 text-slate-600 grid place-items-center text-sm px-4 py-10">
+          No education added yet.
+        </div>
+      ) : (
+        <ul className="space-y-3 flex-1 overflow-auto scrollbar-clear" aria-label="Education history">
+          {education.map((edu) => (
+            <EducationRow key={edu.id} edu={edu} />
+          ))}
+        </ul>
+      )}
     </article>
   );
 }

--- a/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/ExperienceCard.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import { AdminContext } from "../../Contexts/admin_context";
 import { apiFetch } from "../../lib/api";
 import type { Experience } from "./types";
@@ -10,9 +10,8 @@ type ExperienceCardProps = {
 
 export default function ExperienceCard({ experience, setExperience }: ExperienceCardProps) {
   const { isAdmin } = useContext(AdminContext);
-  if (!Array.isArray(experience) || experience.length === 0) return null;
 
-  const ordered = experience.slice().sort((a, b) => a.order_index - b.order_index);
+  const ordered = useMemo(() => experience.slice().sort((a, b) => a.order_index - b.order_index), [experience]);
   const [bulletDrafts, setBulletDrafts] = useState<Record<number, string>>({});
   const [savingBullets, setSavingBullets] = useState<Record<number, boolean>>({});
   const [bulletErrors, setBulletErrors] = useState<Record<number, string | null>>({});
@@ -71,10 +70,19 @@ export default function ExperienceCard({ experience, setExperience }: Experience
     }
   };
 
+  if (!Array.isArray(experience) || experience.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50/70 p-6 text-sm text-slate-600">
+        No career entries yet.
+      </div>
+    );
+  }
+
   return (
-    <ul className="space-y-3">
+    <ul className="space-y-4">
       {ordered.map((exp, index) => {
         const endDisplay = exp.present ? "Present" : exp.end_date;
+        const range = `${cleanDate(exp.start_date)} – ${exp.present ? "Present" : cleanDate(endDisplay)}`;
         return (
           <li
             key={exp.id}
@@ -86,22 +94,28 @@ export default function ExperienceCard({ experience, setExperience }: Experience
               const fromIndex = Number(e.dataTransfer.getData("text/plain"));
               handleDrop(fromIndex, index);
             }}
-            className={`group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/90 p-4 transition-all duration-200 shadow-sm hover:shadow-md ${
+            className={`group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/95 p-4 transition-all duration-200 shadow-sm hover:shadow-md ${
               isAdmin ? "cursor-grab" : "cursor-default"
             }`}
           >
-            <div className="absolute right-4 top-3 bottom-3 w-px bg-slate-200/80" aria-hidden />
-            <div className="grid grid-cols-[1fr_auto] items-start gap-4">
+            <div className="absolute left-4 top-4 bottom-4 w-px bg-slate-200/80" aria-hidden />
+            <div className="grid grid-cols-[auto_1fr_auto] items-start gap-4">
+              <div className="flex flex-col items-center gap-2 text-[11px] text-slate-600">
+                <span className="h-8 w-8 rounded-full bg-blue-50 text-blue-700 border border-blue-100 grid place-items-center font-semibold">
+                  {index + 1}
+                </span>
+                {exp.present && <span className="rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100 px-2 py-1">Current</span>}
+              </div>
               <div className="flex items-start gap-4">
                 <img src={exp.image_url} alt={exp.company} className="w-12 h-12 rounded-xl object-cover shadow-sm border border-slate-200" />
                 <div className="min-w-0 flex-1 space-y-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <p className="text-sm font-semibold text-slate-900 truncate">{exp.company}</p>
-                    {isAdmin && <span className="text-[10px] uppercase tracking-[0.12em] text-blue-600 bg-blue-50 border border-blue-100 rounded-full px-2 py-0.5">drag</span>}
+                    {isAdmin && <span className="text-[10px] uppercase tracking-[0.12em] text-blue-600 bg-blue-50 border border-blue-100 rounded-full px-2 py-0.5">Drag</span>}
                   </div>
                   <p className="text-xs text-slate-600 truncate">{exp.position}</p>
-                  <p className="text-xs text-slate-500">{cleanDate(exp.start_date)} – {exp.present ? "Present" : cleanDate(endDisplay)}</p>
-                  {exp.description && <p className="text-sm text-slate-700 line-clamp-2">{exp.description}</p>}
+                  <p className="text-xs text-slate-500">{range}</p>
+                  {exp.description && <p className="text-sm text-slate-700 leading-snug">{exp.description}</p>}
                   {Array.isArray(exp.bullet_points) && exp.bullet_points.length > 0 && (
                     <ul className="mt-2 space-y-1 text-sm text-slate-800 list-disc list-inside">
                       {exp.bullet_points.map((point, idx) => (
@@ -139,9 +153,9 @@ export default function ExperienceCard({ experience, setExperience }: Experience
               <div className="flex flex-col items-end gap-2 text-right min-w-[120px]">
                 <div className="flex items-center gap-2 text-[11px] text-slate-600">
                   <span className="h-2.5 w-2.5 rounded-full bg-blue-500" />
-                  <span className="rounded-full bg-slate-50 border border-slate-200 px-2 py-1">#{index + 1}</span>
+                  <span className="rounded-full bg-slate-50 border border-slate-200 px-2 py-1">{range}</span>
                 </div>
-                {exp.present && <span className="rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100 px-2 py-1 text-[11px]">Current</span>}
+                {exp.present && <span className="rounded-full bg-emerald-50 text-emerald-700 border border-emerald-100 px-2 py-1 text-[11px]">Active</span>}
               </div>
             </div>
           </li>

--- a/static/anoweb-front/src/Pages/Home/ProfileCard.tsx
+++ b/static/anoweb-front/src/Pages/Home/ProfileCard.tsx
@@ -4,6 +4,12 @@ type ProfileCardProps = {
   profile: Profile | null;
 };
 
+const fields = [
+  { label: "Email", key: "email" as const, icon: "✉", buildHref: (value: string) => `mailto:${value}` },
+  { label: "GitHub", key: "github" as const, icon: "🐙", buildHref: (value: string) => value },
+  { label: "LinkedIn", key: "linkedin" as const, icon: "💼", buildHref: (value: string) => value },
+];
+
 export default function ProfileCard({ profile }: ProfileCardProps) {
   if (!profile) {
     return (
@@ -21,21 +27,36 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
             className="w-28 h-28 md:w-32 md:h-32 rounded-2xl object-cover border border-slate-200 shadow-sm"
           />
         </div>
-        <div className="min-w-0 space-y-2 flex-1">
-          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Profile</p>
-          <h2 className="text-2xl font-semibold text-slate-900">{profile.name}</h2>
-          <p className="text-slate-700 leading-relaxed line-clamp-3 whitespace-pre-line">{profile.bio}</p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
-            <a href={`mailto:${profile.email}`} className="chip-soft">
-              {profile.email}
-            </a>
-            <a href={profile.github} target="_blank" rel="noopener noreferrer" className="chip-soft">
-              GitHub
-            </a>
-            <a href={profile.linkedin} target="_blank" rel="noopener noreferrer" className="chip-soft">
-              LinkedIn
-            </a>
+        <div className="min-w-0 space-y-3 flex-1">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Profile</p>
+            <h2 className="text-2xl font-semibold text-slate-900">{profile.name}</h2>
+            <p className="text-slate-700 leading-relaxed whitespace-pre-line">{profile.bio}</p>
           </div>
+
+          <dl className="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-2">
+            {fields.map((field) => {
+              const value = profile[field.key];
+              const href = value ? field.buildHref(value) : undefined;
+              return (
+                <div key={field.key} className="rounded-2xl border border-slate-200 bg-slate-50/60 p-3 space-y-1 shadow-sm">
+                  <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 flex items-center gap-1">
+                    <span aria-hidden>{field.icon}</span>
+                    {field.label}
+                  </dt>
+                  <dd className="text-sm text-slate-800 break-all">
+                    {href ? (
+                      <a className="text-blue-700 hover:text-blue-800 font-semibold" href={href} target="_blank" rel="noreferrer">
+                        {value}
+                      </a>
+                    ) : (
+                      <span className="text-slate-500">Not provided</span>
+                    )}
+                  </dd>
+                </div>
+              );
+            })}
+          </dl>
         </div>
       </div>
     </article>

--- a/static/anoweb-front/src/style.css
+++ b/static/anoweb-front/src/style.css
@@ -53,6 +53,10 @@
   color: #24292f;
   line-height: 1.7;
   font-size: 16px;
+  background: #fff;
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid #d0d7de;
 }
 .markdown-body h1,
 .markdown-body h2,
@@ -60,6 +64,26 @@
   color: #1f2937;
   padding-bottom: 0.3em;
   border-bottom: 1px solid #d0d7de;
+  margin-top: 1.4em;
+  margin-bottom: 0.75em;
+}
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  color: #111827;
+  margin-top: 1.2em;
+  margin-bottom: 0.6em;
+}
+.markdown-body p { margin: 0.75em 0; }
+.markdown-body ul,
+.markdown-body ol { margin: 0.75em 0 0.75em 1.4em; }
+.markdown-body li { margin: 0.35em 0; }
+.markdown-body blockquote {
+  border-left: 4px solid #d0d7de;
+  padding: 0.25em 1em;
+  color: #4b5563;
+  background: #f6f8fa;
+  border-radius: 0 12px 12px 0;
 }
 .markdown-body code {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
@@ -71,6 +95,35 @@
 .markdown-body pre code {
   padding: 0;
   background: transparent;
+}
+.markdown-body pre {
+  background: #f6f8fa;
+  border-radius: 12px;
+  padding: 14px;
+  border: 1px solid #d0d7de;
+  overflow: auto;
+}
+.markdown-body hr {
+  border: 0;
+  border-top: 1px solid #d0d7de;
+  margin: 1.5em 0;
+}
+.markdown-body table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+}
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid #d0d7de;
+  padding: 8px 10px;
+}
+.markdown-body tr:nth-child(2n) {
+  background: #f6f8fa;
+}
+.markdown-body input[type="checkbox"] {
+  margin-right: 8px;
+  accent-color: #2563eb;
 }
 .markdown-pre {
   padding: 16px;


### PR DESCRIPTION
## Summary
- Refine the markdown workspace with GitHub-style editing, toolbar shortcuts, word stats, and code-copy support plus a demo fallback for offline preview
- Refresh home page cards for education, profile, and career path with clearer sections, labels, and better empty/link handling
- Extend markdown styling to mirror GitHub rendering for headings, lists, tables, and code blocks

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b9408e7f08332b9ffd8ef5a0bba24)