### PR TITLE
fix: Restore vite output directory to /var/www/anoweb

### DIFF
--- a/static/anoweb-front/vite.config.ts
+++ b/static/anoweb-front/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   build: {
-    outDir: 'dist',
+    outDir: '/var/www/anoweb',
     emptyOutDir: true
   }
 })


### PR DESCRIPTION
## Issue

The previous PR (#29) accidentally changed the vite output directory from `/var/www/anoweb` to `dist` during testing. This caused the built frontend files to be placed in the wrong location, preventing the UI changes from being visible.

## Fix

Restored the original output directory in `vite.config.ts`:
```typescript
outDir: '/var/www/anoweb'
```

## Impact

After merging this fix and rebuilding the frontend, all the new features will be visible:
- Statistics cards on home page
- Guest sign-up invitation
- Activity page
- Mystery code system
- Admin edit mode toggle
- Guest popup

## Action Required

After merging, rebuild the frontend:
```bash
cd static/anoweb-front
pnpm install
pnpm build
```

Then hard refresh the browser to see all changes.